### PR TITLE
[PoC] add SDVX clear tierlist

### DIFF
--- a/collections/charts-sdvx.json
+++ b/collections/charts-sdvx.json
@@ -58,7 +58,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -150,7 +156,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 2,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -472,7 +484,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 6,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -564,7 +582,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 7,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -1087,7 +1111,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 14,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -1478,7 +1508,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 19,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -1823,7 +1859,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 24,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -2283,7 +2325,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 30,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "超個人差",
+				"value": 16
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -2306,7 +2354,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 30,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -2674,7 +2728,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 36,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -2697,7 +2757,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 36,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -2766,7 +2832,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 37,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -2858,7 +2930,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 39,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -3088,7 +3166,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 42,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -3364,7 +3448,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 47,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -3387,7 +3477,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 47,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -3479,7 +3575,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 48,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4074,7 +4176,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 56,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4235,7 +4343,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 58,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4327,7 +4441,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 59,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4396,7 +4516,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 60,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4419,7 +4545,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 60,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4580,7 +4712,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 62,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4649,7 +4787,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 63,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4672,7 +4816,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 63,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4833,7 +4983,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 65,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -4925,7 +5081,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 66,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5086,7 +5248,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 68,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5178,7 +5346,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 69,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5270,7 +5444,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 70,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5362,7 +5542,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 71,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5454,7 +5640,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 72,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5523,7 +5715,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 73,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5546,7 +5744,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 73,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -5937,7 +6141,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 78,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -6027,7 +6237,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 79,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -6115,7 +6331,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 80,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -6544,7 +6766,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 86,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -6636,7 +6864,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 87,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -6931,7 +7165,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 91,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -6954,7 +7194,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 91,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -7299,7 +7545,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 96,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -7368,7 +7620,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 97,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -7644,7 +7902,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 101,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -7667,7 +7931,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 101,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -7828,7 +8098,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 103,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -7918,7 +8194,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 104,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8031,7 +8313,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 105,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8189,7 +8477,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 107,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8255,7 +8549,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 108,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8322,7 +8622,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 109,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8345,7 +8651,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 109,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8779,7 +9091,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 115,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8848,7 +9166,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 116,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A - 15E",
+				"value": 17
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8871,7 +9195,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 116,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8940,7 +9270,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 117,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -8963,7 +9299,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 117,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9055,7 +9397,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 118,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9147,7 +9495,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 120,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9239,7 +9593,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 121,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9308,7 +9668,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 122,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9331,7 +9697,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 122,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9400,7 +9772,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 123,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9423,7 +9801,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 123,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9492,7 +9876,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 124,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9515,7 +9905,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 124,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9584,7 +9980,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 125,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9607,7 +10009,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 125,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9676,7 +10084,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 126,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9699,7 +10113,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 126,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -9860,7 +10280,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 128,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -10019,7 +10445,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 130,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -10307,7 +10739,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 134,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -10649,7 +11087,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 139,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -10672,7 +11116,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 139,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -11293,7 +11743,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 151,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -11316,7 +11772,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 151,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -11591,7 +12053,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 155,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -11613,7 +12081,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 155,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -11789,7 +12263,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 158,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -12311,7 +12791,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 166,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18D - 17F",
+				"value": 17
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -12334,7 +12820,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 166,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -12813,7 +13305,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 173,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -12835,7 +13333,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 173,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -13165,7 +13669,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 180,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16S",
+				"value": 16.9
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -13187,7 +13697,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 180,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -13473,7 +13989,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 184,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -13672,7 +14194,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 187,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"booth",
 			"inf",
@@ -14058,7 +14586,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 194,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -14844,7 +15378,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 208,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15086,7 +15626,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 211,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15240,7 +15786,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 213,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15284,7 +15836,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 214,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15306,7 +15864,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 214,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15438,7 +16002,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 216,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15482,7 +16052,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 216,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15724,7 +16300,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 220,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15790,7 +16372,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 221,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15834,7 +16422,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 221,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15944,7 +16538,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 223,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -15966,7 +16566,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 223,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -16296,7 +16902,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 228,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -16318,7 +16930,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 228,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -16384,7 +17002,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 229,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A - 17C",
+				"value": 17
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -16406,7 +17030,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 229,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -16670,7 +17300,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 234,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17396,7 +18032,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 247,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C - 17F",
+				"value": 17
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17440,7 +18082,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 247,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18SS",
+				"value": 18.9
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17550,7 +18198,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 250,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17572,7 +18226,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 250,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17638,7 +18298,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 251,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17660,7 +18326,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 251,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17726,7 +18398,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 252,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17748,7 +18426,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 252,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -17968,7 +18652,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 255,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18166,7 +18856,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 258,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18188,7 +18884,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 258,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18254,7 +18956,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 259,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18276,7 +18984,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 259,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18540,7 +19254,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 263,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18826,7 +19546,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 267,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18892,7 +19618,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 268,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -18958,7 +19690,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 269,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -19024,7 +19762,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 271,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -19090,7 +19834,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 272,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -19156,7 +19906,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 273,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -19200,7 +19956,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 273,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -19332,7 +20094,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 275,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -19552,7 +20320,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 278,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -19816,7 +20590,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 282,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20014,7 +20794,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 286,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20080,7 +20866,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 287,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20212,7 +21004,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 289,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20476,7 +21274,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 293,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20608,7 +21412,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 295,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20652,7 +21462,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 295,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20894,7 +21710,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 299,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -20938,7 +21760,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 299,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -21114,7 +21942,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 302,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -21246,7 +22080,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 304,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -21290,7 +22130,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 304,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -21400,7 +22246,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 306,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -21994,7 +22846,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 316,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -22317,7 +23175,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 321,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -22381,7 +23245,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 322,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -22403,7 +23273,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 322,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -22535,7 +23411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 324,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -22667,7 +23549,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 326,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -22865,7 +23753,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 329,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23063,7 +23957,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 332,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23129,7 +24029,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 333,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23173,7 +24079,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 333,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23547,7 +24459,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 339,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23591,7 +24509,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 339,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23701,7 +24625,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 341,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23723,7 +24653,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 341,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23789,7 +24725,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 342,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23855,7 +24797,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 343,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -23987,7 +24935,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 345,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24053,7 +25007,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 346,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24119,7 +25079,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 347,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24185,7 +25151,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 348,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24581,7 +25553,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 356,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24669,7 +25647,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 357,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24757,7 +25741,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 358,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24823,7 +25813,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 359,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24845,7 +25841,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 359,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24911,7 +25913,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 360,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -24933,7 +25941,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 360,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25021,7 +26035,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 361,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25087,7 +26107,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 362,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25109,7 +26135,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 362,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25175,7 +26207,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 363,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25197,7 +26235,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 363,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25263,7 +26307,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 364,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25285,7 +26335,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 364,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25351,7 +26407,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 365,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25373,7 +26435,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 365,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25439,7 +26507,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 366,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25461,7 +26535,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 366,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25527,7 +26607,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 367,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25549,7 +26635,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 367,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25637,7 +26729,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 368,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25725,7 +26823,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 369,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25791,7 +26895,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 370,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25813,7 +26923,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 370,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25901,7 +27017,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 372,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25967,7 +27089,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 373,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -25989,7 +27117,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 373,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26055,7 +27189,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 374,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26077,7 +27217,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 374,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26165,7 +27311,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 375,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26231,7 +27383,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 376,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26253,7 +27411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 376,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26341,7 +27505,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 377,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26407,7 +27577,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 378,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26539,7 +27715,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 380,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26605,7 +27787,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 381,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26800,7 +27988,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 384,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -26998,7 +28192,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 387,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -27196,7 +28396,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 390,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -27328,7 +28534,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 392,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -27394,7 +28606,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 393,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -27438,7 +28656,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 393,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -27482,7 +28706,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 394,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -27614,7 +28844,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 396,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -27743,7 +28979,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 398,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -28139,7 +29381,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 404,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -28337,7 +29585,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 407,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -28403,7 +29657,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 408,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -28469,7 +29729,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 409,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -28667,7 +29933,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 413,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -28733,7 +30005,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 414,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -28997,7 +30275,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 418,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -29063,7 +30347,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 419,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -29129,7 +30419,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 420,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -29539,7 +30835,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 426,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -29603,7 +30905,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 427,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -29732,7 +31040,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 429,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -29798,7 +31112,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 430,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -29952,7 +31272,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 432,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -30300,7 +31626,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 437,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -30428,7 +31760,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 439,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -30646,7 +31984,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 442,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -30712,7 +32056,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 443,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -30734,7 +32084,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 443,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -30799,7 +32155,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 444,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -30820,7 +32182,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 444,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -31148,7 +32516,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 449,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -31214,7 +32588,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 450,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -31544,7 +32924,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 456,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -31741,7 +33127,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 459,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -31762,7 +33154,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 459,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32016,7 +33414,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 463,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32076,7 +33480,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 464,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32137,7 +33547,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 465,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32201,7 +33617,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 466,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -32333,7 +33755,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 468,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -32397,7 +33825,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 469,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32457,7 +33891,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 470,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32580,7 +34020,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 472,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32641,7 +34087,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 473,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -32848,7 +34300,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 476,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -33041,7 +34499,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 479,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -33909,7 +35373,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 492,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -33997,7 +35467,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 493,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34063,7 +35539,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 494,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16S",
+				"value": 16.9
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34085,7 +35567,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 494,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34151,7 +35639,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 495,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34173,7 +35667,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 495,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34238,7 +35738,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 496,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -34301,7 +35807,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 497,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -34365,7 +35877,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 498,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34430,7 +35948,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 499,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -34494,7 +36018,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 500,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34559,7 +36089,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 501,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -34622,7 +36158,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 502,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -34686,7 +36228,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 503,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34751,7 +36299,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 504,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -34814,7 +36368,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 505,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -34878,7 +36438,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 506,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -34943,7 +36509,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 507,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -35007,7 +36579,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 508,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -35073,7 +36651,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 509,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -35138,7 +36722,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 510,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -35585,7 +37175,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 517,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -35648,7 +37244,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 518,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -35863,7 +37465,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 521,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -35928,7 +37536,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 522,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36118,7 +37732,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 525,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -36140,7 +37760,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 525,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -36205,7 +37831,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 526,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36394,7 +38026,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 529,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36457,7 +38095,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 530,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36520,7 +38164,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 531,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36583,7 +38233,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 532,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36625,7 +38281,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 532,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36730,7 +38392,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 534,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36793,7 +38461,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 535,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36856,7 +38530,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 536,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36919,7 +38599,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 537,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -36982,7 +38668,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 538,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37045,7 +38737,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 539,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37109,7 +38807,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 540,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -37131,7 +38835,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 540,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -37196,7 +38906,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 541,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37260,7 +38976,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 542,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -37282,7 +39004,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 542,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -37347,7 +39075,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 543,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37536,7 +39270,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 546,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37599,7 +39339,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 547,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37663,7 +39409,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 548,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -37685,7 +39437,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 548,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -37750,7 +39508,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 549,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37813,7 +39577,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 550,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37876,7 +39646,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 551,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19B - 17C",
+				"value": 18
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -37940,7 +39716,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 552,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -38028,7 +39810,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 553,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -38114,7 +39902,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 554,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"inf",
 			"gw",
@@ -38177,7 +39971,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 555,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -38239,7 +40039,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 556,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -38299,7 +40105,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 557,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -38482,7 +40294,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 560,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -38606,7 +40424,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 562,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39233,7 +41057,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 572,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39356,7 +41186,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 574,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39482,7 +41318,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 576,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39544,7 +41386,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 579,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39564,7 +41412,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 579,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39625,7 +41479,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 580,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39688,7 +41548,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 581,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39814,7 +41680,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 583,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -39940,7 +41812,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 585,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40066,7 +41944,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 587,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40192,7 +42076,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 589,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40318,7 +42208,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 591,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40381,7 +42277,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 592,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40444,7 +42346,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 593,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40570,7 +42478,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 595,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40696,7 +42610,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 597,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40759,7 +42679,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 598,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B - 17C",
+				"value": 17
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40822,7 +42748,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 599,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -40885,7 +42817,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 600,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41137,7 +43075,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 604,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41263,7 +43207,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 606,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41326,7 +43276,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 607,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41389,7 +43345,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 608,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41515,7 +43477,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 610,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41578,7 +43546,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 611,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41641,7 +43615,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 612,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41767,7 +43747,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 615,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41830,7 +43816,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 616,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -41893,7 +43885,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 617,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42271,7 +44269,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 623,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42333,7 +44337,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 624,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42353,7 +44363,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 624,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42435,7 +44451,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 625,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42498,7 +44520,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 626,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42624,7 +44652,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 628,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42687,7 +44721,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 629,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42750,7 +44790,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 630,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42812,7 +44858,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 631,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42873,7 +44925,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 632,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42936,7 +44994,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 633,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -42999,7 +45063,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 634,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43062,7 +45132,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 635,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43125,7 +45201,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 636,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43146,7 +45228,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 636,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43209,7 +45297,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 637,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43272,7 +45366,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 638,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43335,7 +45435,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 639,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43398,7 +45504,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 640,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43461,7 +45573,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 641,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43524,7 +45642,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 642,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43587,7 +45711,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 643,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43650,7 +45780,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 644,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43713,7 +45849,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 645,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43839,7 +45981,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 647,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43902,7 +46050,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 648,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -43965,7 +46119,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 649,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44028,7 +46188,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 650,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44091,7 +46257,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 651,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44154,7 +46326,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 652,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44217,7 +46395,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 653,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44280,7 +46464,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 654,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44343,7 +46533,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 655,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44406,7 +46602,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 656,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44469,7 +46671,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 657,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44532,7 +46740,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 658,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44657,7 +46871,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 660,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44677,7 +46897,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 660,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44738,7 +46964,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 661,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44759,7 +46991,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 661,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18S",
+				"value": 18.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -44882,7 +47120,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 663,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45131,7 +47375,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 667,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45194,7 +47444,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 668,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45320,7 +47576,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 670,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45509,7 +47771,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 673,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45572,7 +47840,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 674,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45635,7 +47909,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 675,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45698,7 +47978,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 676,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45761,7 +48047,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 677,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45887,7 +48179,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 679,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -45950,7 +48248,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 680,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46013,7 +48317,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 681,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46076,7 +48386,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 682,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46139,7 +48455,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 683,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46202,7 +48524,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 684,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46223,7 +48551,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 684,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46285,7 +48619,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 685,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46346,7 +48686,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 686,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46409,7 +48755,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 687,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46535,7 +48887,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 689,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46661,7 +49019,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 691,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46682,7 +49046,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 691,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46745,7 +49115,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 692,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46766,7 +49142,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 692,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46829,7 +49211,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 693,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46850,7 +49238,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 693,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46913,7 +49307,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 694,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46934,7 +49334,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 694,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -46997,7 +49403,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 695,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47018,7 +49430,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 695,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47081,7 +49499,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 696,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47144,7 +49568,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 697,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47207,7 +49637,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 698,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47270,7 +49706,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 699,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47459,7 +49901,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 702,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47522,7 +49970,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 703,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47585,7 +50039,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 704,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47606,7 +50066,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 704,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47668,7 +50134,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 705,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47688,7 +50160,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 705,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47748,7 +50226,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 706,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47768,7 +50252,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 706,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47828,7 +50318,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 707,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47848,7 +50344,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 707,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47909,7 +50411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 708,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47972,7 +50480,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 709,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -47993,7 +50507,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 709,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48182,7 +50702,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 712,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48308,7 +50834,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 714,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48392,7 +50924,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 715,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48455,7 +50993,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 716,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48518,7 +51062,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 717,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48581,7 +51131,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 718,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48644,7 +51200,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 719,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48707,7 +51269,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 720,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -48833,7 +51401,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 722,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49022,7 +51596,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 725,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49085,7 +51665,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 726,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49148,7 +51734,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 727,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49211,7 +51803,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 728,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49274,7 +51872,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 729,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49337,7 +51941,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 730,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49400,7 +52010,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 731,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49463,7 +52079,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 732,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49526,7 +52148,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 733,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49652,7 +52280,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 735,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49778,7 +52412,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 737,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -49967,7 +52607,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 740,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50030,7 +52676,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 741,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50093,7 +52745,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 742,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50156,7 +52814,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 743,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50219,7 +52883,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 744,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50345,7 +53015,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 746,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50408,7 +53084,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 747,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50534,7 +53216,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 749,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -50723,7 +53411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 752,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -51038,7 +53732,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 757,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -51101,7 +53801,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 758,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -51164,7 +53870,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 759,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -51227,7 +53939,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 760,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -51290,7 +54008,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 761,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -51479,7 +54203,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 764,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -51559,7 +54289,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 765,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -51717,7 +54453,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 767,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -52018,7 +54760,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 772,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -52207,7 +54955,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 776,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -52396,7 +55150,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 779,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -52621,7 +55381,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 782,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -52808,7 +55574,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 785,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -52871,7 +55643,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 786,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -52934,7 +55712,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 787,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -52997,7 +55781,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 788,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53060,7 +55850,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 789,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53123,7 +55919,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 790,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53186,7 +55988,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 791,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53207,7 +56015,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 791,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20B",
+				"value": 20.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53270,7 +56084,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 792,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53333,7 +56153,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 793,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53396,7 +56222,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 794,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53459,7 +56291,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 795,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53522,7 +56360,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 796,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53585,7 +56429,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 797,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53648,7 +56498,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 798,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53837,7 +56693,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 801,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53900,7 +56762,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 802,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -53963,7 +56831,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 803,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54026,7 +56900,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 804,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54089,7 +56969,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 805,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54152,7 +57038,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 806,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54215,7 +57107,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 807,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54278,7 +57176,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 808,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54341,7 +57245,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 809,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54404,7 +57314,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 810,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54467,7 +57383,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 811,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54530,7 +57452,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 812,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54656,7 +57584,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 814,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54782,7 +57716,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 816,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54845,7 +57785,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 817,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54908,7 +57854,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 818,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -54971,7 +57923,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 819,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55114,7 +58072,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 821,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55198,7 +58162,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 822,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55261,7 +58231,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 823,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55324,7 +58300,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 824,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55345,7 +58327,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 824,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55427,7 +58415,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 825,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -55488,7 +58482,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 826,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55572,7 +58572,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 827,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55656,7 +58662,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 828,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55719,7 +58731,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 829,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55740,7 +58758,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 829,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55803,7 +58827,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 830,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55824,7 +58854,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 830,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55887,7 +58923,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 831,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55908,7 +58950,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 831,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -55971,7 +59019,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 832,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56034,7 +59088,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 833,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56116,7 +59176,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 834,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -56177,7 +59243,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 835,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56240,7 +59312,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 836,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56303,7 +59381,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 837,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56366,7 +59450,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 838,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56429,7 +59519,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 839,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56513,7 +59609,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 841,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56576,7 +59678,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 842,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56702,7 +59810,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 844,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56891,7 +60005,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 847,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -56954,7 +60074,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 848,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57017,7 +60143,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 849,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57143,7 +60275,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 851,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57225,7 +60363,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 852,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -57286,7 +60430,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 853,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57412,7 +60562,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 855,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57538,7 +60694,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 857,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57601,7 +60763,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 858,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57664,7 +60832,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 859,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -57929,7 +61103,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 863,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -58178,7 +61358,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 867,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -58430,7 +61616,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 871,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -58493,7 +61685,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 872,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -58556,7 +61754,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 873,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -58745,7 +61949,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 876,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -58827,7 +62037,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 877,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -58987,7 +62203,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 879,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59067,7 +62289,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 880,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59147,7 +62375,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 881,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59227,7 +62461,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 882,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59307,7 +62547,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 883,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59450,7 +62696,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 885,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59530,7 +62782,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 886,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59610,7 +62868,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 887,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59690,7 +62954,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 888,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59770,7 +63040,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 889,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59850,7 +63126,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 890,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -59930,7 +63212,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 891,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -60010,7 +63298,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 892,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -60071,7 +63365,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 893,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -60153,7 +63453,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 894,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -60233,7 +63539,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 895,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -60376,7 +63688,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 897,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -60580,7 +63898,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 900,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -60601,7 +63925,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 900,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -60664,7 +63994,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 901,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -60727,7 +64063,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 902,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16F",
+				"value": 16
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -60748,7 +64090,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 902,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -60811,7 +64159,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 903,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -60937,7 +64291,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 905,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61000,7 +64360,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 906,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61063,7 +64429,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 907,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61126,7 +64498,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 908,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61147,7 +64525,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 908,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61210,7 +64594,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 909,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61231,7 +64621,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 909,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61294,7 +64690,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 910,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61315,7 +64717,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 910,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61378,7 +64786,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 911,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61399,7 +64813,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 911,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61462,7 +64882,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 912,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61483,7 +64909,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 912,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61546,7 +64978,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 913,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61567,7 +65005,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 913,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61630,7 +65074,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 914,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61651,7 +65101,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 914,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61714,7 +65170,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 915,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61735,7 +65197,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 915,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61861,7 +65329,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 917,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61882,7 +65356,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 917,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61945,7 +65425,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 918,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -61966,7 +65452,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 918,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62050,7 +65542,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 919,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62134,7 +65632,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 920,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62218,7 +65722,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 921,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62281,7 +65791,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 922,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62302,7 +65818,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 922,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62407,7 +65929,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 923,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62448,7 +65976,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 924,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62509,7 +66043,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 925,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62635,7 +66175,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 927,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62656,7 +66202,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 927,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -62738,7 +66290,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 928,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -62798,7 +66356,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 929,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -62818,7 +66382,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 929,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -62898,7 +66468,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 930,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -62958,7 +66534,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 931,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -62978,7 +66560,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 931,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -63056,7 +66644,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 932,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63132,7 +66726,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 933,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F-",
+				"value": 17
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63208,7 +66808,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 934,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63284,7 +66890,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 935,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63360,7 +66972,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 936,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63436,7 +67054,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 937,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63512,7 +67136,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 938,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63571,7 +67201,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 939,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -63708,7 +67344,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 941,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63727,7 +67369,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 941,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -63879,7 +67527,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 943,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -64098,7 +67752,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 946,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -64174,7 +67834,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 947,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -64250,7 +67916,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 948,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -64389,7 +68061,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 950,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -64490,7 +68168,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 951,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -64532,7 +68216,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 952,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -64595,7 +68285,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 953,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"gw",
 			"heaven",
@@ -64677,7 +68373,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 954,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -64835,7 +68537,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 956,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -64913,7 +68621,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 957,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -64991,7 +68705,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 958,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -65067,7 +68787,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 959,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -65143,7 +68869,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 960,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -65221,7 +68953,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 961,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65301,7 +69039,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 962,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65381,7 +69125,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 963,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65441,7 +69191,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 964,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65461,7 +69217,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 964,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65541,7 +69303,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 965,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65621,7 +69389,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 966,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65701,7 +69475,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 967,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C - 17C",
+				"value": 17
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65781,7 +69561,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 968,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65861,7 +69647,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 969,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -65941,7 +69733,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 970,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66001,7 +69799,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 971,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66021,7 +69825,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 971,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66101,7 +69911,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 972,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66261,7 +70077,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 974,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66341,7 +70163,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 975,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66421,7 +70249,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 976,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66501,7 +70335,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 977,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66581,7 +70421,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 978,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66661,7 +70507,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 979,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66721,7 +70573,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 980,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66741,7 +70599,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 980,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66821,7 +70685,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 981,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66901,7 +70771,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 982,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -66981,7 +70857,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 983,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67141,7 +71023,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 985,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67221,7 +71109,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 986,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67381,7 +71275,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 988,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67461,7 +71361,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 989,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67621,7 +71527,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 991,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67701,7 +71613,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 992,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67781,7 +71699,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 993,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67861,7 +71785,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 994,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -67941,7 +71871,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 995,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68021,7 +71957,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 996,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68101,7 +72043,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 997,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68181,7 +72129,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 998,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68261,7 +72215,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 999,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68341,7 +72301,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1000,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68421,7 +72387,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1001,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68501,7 +72473,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1002,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68581,7 +72559,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1003,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68741,7 +72725,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1005,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68821,7 +72811,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1006,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F-",
+				"value": 17
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68901,7 +72897,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1007,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -68981,7 +72983,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1008,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69061,7 +73069,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1009,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69141,7 +73155,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1010,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69221,7 +73241,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1011,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69301,7 +73327,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1012,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69381,7 +73413,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1013,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69541,7 +73579,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1015,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69621,7 +73665,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1016,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69701,7 +73751,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1017,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69781,7 +73837,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1018,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69861,7 +73923,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1019,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -69941,7 +74009,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1020,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70021,7 +74095,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1021,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70101,7 +74181,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1022,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70181,7 +74267,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1023,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70241,7 +74333,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1024,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70261,7 +74359,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1024,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70321,7 +74425,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1025,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70341,7 +74451,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1025,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70421,7 +74537,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1026,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F-",
+				"value": 17
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70501,7 +74623,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1027,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70561,7 +74689,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1028,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70581,7 +74715,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1028,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20B",
+				"value": 20.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70661,7 +74801,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1029,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70721,7 +74867,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1030,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70741,7 +74893,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1030,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70801,7 +74959,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1031,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70821,7 +74985,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1031,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70881,7 +75051,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1032,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70901,7 +75077,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1032,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70961,7 +75143,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1033,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -70981,7 +75169,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1033,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71061,7 +75255,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1034,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71121,7 +75321,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1035,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71141,7 +75347,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1035,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71201,7 +75413,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1036,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71221,7 +75439,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1036,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20B",
+				"value": 20.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71281,7 +75505,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1037,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71301,7 +75531,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1037,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71361,7 +75597,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1038,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71381,7 +75623,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1038,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71461,7 +75709,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1039,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71541,7 +75795,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1040,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71621,7 +75881,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1041,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71701,7 +75967,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1042,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71761,7 +76033,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1043,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71781,7 +76059,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1043,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71841,7 +76125,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1044,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71861,7 +76151,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1044,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -71941,7 +76237,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1045,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72021,7 +76323,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1046,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72101,7 +76409,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1047,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72181,7 +76495,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1048,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72241,7 +76561,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1049,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72261,7 +76587,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1049,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72341,7 +76673,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1050,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72421,7 +76759,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1051,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72501,7 +76845,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1052,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72581,7 +76931,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1053,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72721,7 +77077,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1055,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72741,7 +77103,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1055,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72819,7 +77187,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1056,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -72953,7 +77327,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1058,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -72973,7 +77353,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1058,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73033,7 +77419,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1059,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73053,7 +77445,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1059,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73133,7 +77531,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1060,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73213,7 +77617,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1061,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73273,7 +77683,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1062,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73293,7 +77709,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1062,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73371,7 +77793,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1063,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -73449,7 +77877,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1064,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73529,7 +77963,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1065,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73605,7 +78045,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1066,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -73681,7 +78127,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1067,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -73759,7 +78211,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1068,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -73835,7 +78293,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1069,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -73911,7 +78375,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1070,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -73987,7 +78457,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1071,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -74065,7 +78541,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1072,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A - 18E",
+				"value": 18
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74145,7 +78627,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1073,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74305,7 +78793,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1075,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74385,7 +78879,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1076,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74465,7 +78965,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1077,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74545,7 +79051,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1078,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74625,7 +79137,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1079,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74705,7 +79223,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1080,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74785,7 +79309,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1081,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -74865,7 +79395,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1082,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75025,7 +79561,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1084,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75103,7 +79645,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1085,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -75257,7 +79805,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1087,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75396,7 +79950,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1089,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -75415,7 +79975,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1089,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -75493,7 +80059,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1090,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75573,7 +80145,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1091,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75651,7 +80229,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1092,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -75729,7 +80313,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1093,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75809,7 +80399,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1094,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75949,7 +80545,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1096,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -75969,7 +80571,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1096,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76049,7 +80657,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1097,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76129,7 +80743,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1098,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76189,7 +80809,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1099,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76209,7 +80835,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1099,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A",
+				"value": 20.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76269,7 +80901,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1100,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76289,7 +80927,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1100,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A",
+				"value": 20.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76349,7 +80993,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1101,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76369,7 +81019,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1101,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76429,7 +81085,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1102,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76449,7 +81111,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1102,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76509,7 +81177,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1103,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76529,7 +81203,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1103,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19S",
+				"value": 19.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76589,7 +81269,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1104,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76609,7 +81295,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1104,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76669,7 +81361,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1105,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76689,7 +81387,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1105,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76749,7 +81453,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1106,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76769,7 +81479,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1106,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76829,7 +81545,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1107,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76849,7 +81571,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1107,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76909,7 +81637,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1108,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -76929,7 +81663,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1108,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77009,7 +81749,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1109,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77089,7 +81835,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1110,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77249,7 +82001,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1112,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F-",
+				"value": 17
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77329,7 +82087,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1113,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77409,7 +82173,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1114,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77489,7 +82259,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1115,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77569,7 +82345,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1116,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77629,7 +82411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1117,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77649,7 +82437,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1117,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77727,7 +82521,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1118,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -77803,7 +82603,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1119,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -77879,7 +82685,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1120,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -77937,7 +82749,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1121,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -77957,7 +82775,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1121,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -78113,7 +82937,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1123,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -78193,7 +83023,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1124,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -78273,7 +83109,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1125,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -78353,7 +83195,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1126,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -78433,7 +83281,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1127,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -78513,7 +83367,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1128,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -78591,7 +83451,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1129,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -78665,7 +83531,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1130,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -78737,7 +83609,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1131,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -78811,7 +83689,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1132,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -78885,7 +83769,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1133,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -78961,7 +83851,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1134,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79041,7 +83937,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1135,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79101,7 +84003,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1136,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79121,7 +84029,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1136,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79199,7 +84113,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1137,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -79275,7 +84195,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1138,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -79351,7 +84277,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1139,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -79429,7 +84361,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1140,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79509,7 +84447,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1141,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79589,7 +84533,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1142,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79669,7 +84619,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1143,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79729,7 +84685,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1144,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79749,7 +84711,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1144,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79809,7 +84777,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1145,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79829,7 +84803,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1145,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79909,7 +84889,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1146,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -79989,7 +84975,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1147,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80049,7 +85041,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1148,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80069,7 +85067,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1148,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80149,7 +85153,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1149,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80209,7 +85219,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1150,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80229,7 +85245,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1150,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80309,7 +85331,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1151,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80389,7 +85417,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1152,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80469,7 +85503,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1153,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80549,7 +85589,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1154,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80629,7 +85675,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1155,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80709,7 +85761,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1156,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80789,7 +85847,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1157,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80869,7 +85933,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1158,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -80949,7 +86019,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1159,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81029,7 +86105,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1160,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81109,7 +86191,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1161,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81189,7 +86277,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1162,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81269,7 +86363,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1163,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81349,7 +86449,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1164,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81429,7 +86535,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1165,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81489,7 +86601,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1166,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81509,7 +86627,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1166,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81589,7 +86713,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1167,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81669,7 +86799,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1168,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81749,7 +86885,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1169,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81829,7 +86971,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1170,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81909,7 +87057,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1171,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -81989,7 +87143,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1172,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82069,7 +87229,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1173,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82149,7 +87315,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1174,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82209,7 +87381,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1175,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82229,7 +87407,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1175,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82289,7 +87473,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1176,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82309,7 +87499,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1176,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82369,7 +87565,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1177,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82389,7 +87591,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1177,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82449,7 +87657,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1178,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82469,7 +87683,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1178,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82529,7 +87749,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1179,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82549,7 +87775,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1179,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82629,7 +87861,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1180,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82709,7 +87947,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1181,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82789,7 +88033,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1183,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82869,7 +88119,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1184,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82929,7 +88185,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1185,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -82949,7 +88211,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1185,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A+",
+				"value": 20.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83029,7 +88297,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1186,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83109,7 +88383,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1187,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83169,7 +88449,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1188,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83189,7 +88475,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1188,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83249,7 +88541,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1189,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83269,7 +88567,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1189,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83329,7 +88633,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1190,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83349,7 +88659,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1190,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A+ - 18D",
+				"value": 18
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83409,7 +88725,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1191,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83429,7 +88751,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1191,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83489,7 +88817,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1192,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83509,7 +88843,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1192,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83569,7 +88909,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1193,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83589,7 +88935,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1193,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83669,7 +89021,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1194,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83729,7 +89087,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1195,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83749,7 +89113,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1195,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83809,7 +89179,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1196,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83829,7 +89205,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1196,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83889,7 +89271,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1197,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83909,7 +89297,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1197,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -83989,7 +89383,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1198,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84049,7 +89449,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1199,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84069,7 +89475,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1199,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84129,7 +89541,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1200,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84149,7 +89567,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1200,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84229,7 +89653,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1201,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84309,7 +89739,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1202,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84389,7 +89825,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1203,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84469,7 +89911,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1204,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84549,7 +89997,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1205,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84629,7 +90083,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1206,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84709,7 +90169,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1207,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84789,7 +90255,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1208,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84869,7 +90341,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1209,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -84949,7 +90427,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1210,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85009,7 +90493,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1211,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85029,7 +90519,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1211,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85109,7 +90605,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1212,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85189,7 +90691,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1213,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85269,7 +90777,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1214,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85349,7 +90863,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1215,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85409,7 +90929,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1216,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85429,7 +90955,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1216,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85509,7 +91041,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1217,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85589,7 +91127,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1218,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85669,7 +91213,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1220,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85689,7 +91239,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1220,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85749,7 +91305,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1221,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85769,7 +91331,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1221,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19S - 19E",
+				"value": 19
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85829,7 +91397,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1222,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85849,7 +91423,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1222,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -85927,7 +91507,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1223,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -86005,7 +91591,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1224,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86085,7 +91677,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1225,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86165,7 +91763,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1226,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86245,7 +91849,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1227,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86325,7 +91935,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1228,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86405,7 +92021,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1229,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86485,7 +92107,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1230,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86565,7 +92193,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1231,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86645,7 +92279,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1233,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86725,7 +92365,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1234,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86805,7 +92451,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1235,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86885,7 +92537,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1236,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -86965,7 +92623,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1237,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87045,7 +92709,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1238,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87105,7 +92775,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1239,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87125,7 +92801,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1239,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87185,7 +92867,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1240,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87205,7 +92893,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1240,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87285,7 +92979,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1241,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87365,7 +93065,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1242,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87445,7 +93151,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1243,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87505,7 +93217,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1244,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87525,7 +93243,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1244,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87605,7 +93329,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1245,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87685,7 +93415,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1246,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87765,7 +93501,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1247,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87845,7 +93587,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1248,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -87925,7 +93673,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1249,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88005,7 +93759,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1250,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88085,7 +93845,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1251,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88165,7 +93931,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1252,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88225,7 +93997,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1253,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88245,7 +94023,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1253,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88325,7 +94109,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1254,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88405,7 +94195,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1255,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88485,7 +94281,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1256,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88565,7 +94367,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1257,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88625,7 +94433,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1258,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88645,7 +94459,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1258,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88777,7 +94597,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1260,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88797,7 +94623,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1260,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88877,7 +94709,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1261,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -88957,7 +94795,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1262,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89037,7 +94881,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1263,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89117,7 +94967,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1264,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89197,7 +95053,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1265,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89277,7 +95139,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1266,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89337,7 +95205,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1267,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89357,7 +95231,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1267,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89437,7 +95317,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1268,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89517,7 +95403,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1269,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89577,7 +95469,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1270,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89597,7 +95495,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1270,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A",
+				"value": 20.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89657,7 +95561,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1271,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89677,7 +95587,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1271,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89737,7 +95653,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1272,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89757,7 +95679,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1272,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89817,7 +95745,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1273,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89837,7 +95771,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1273,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89917,7 +95857,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1274,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89977,7 +95923,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1275,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -89997,7 +95949,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1275,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90057,7 +96015,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1276,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90077,7 +96041,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1276,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90137,7 +96107,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1277,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90157,7 +96133,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1277,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90237,7 +96219,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1278,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90317,7 +96305,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1279,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90397,7 +96391,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1280,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90477,7 +96477,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1281,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90557,7 +96563,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1282,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90637,7 +96649,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1283,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90717,7 +96735,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1284,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90797,7 +96821,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1285,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -90875,7 +96905,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1286,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -90951,7 +96987,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1287,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91025,7 +97067,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1288,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -91080,7 +97128,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1289,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91099,7 +97153,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1289,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91175,7 +97235,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1290,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91249,7 +97315,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1291,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -91323,7 +97395,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1292,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91399,7 +97477,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1293,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91475,7 +97559,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1294,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91551,7 +97641,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1295,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91627,7 +97723,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1296,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91703,7 +97805,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1297,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -91759,7 +97867,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1298,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -91777,7 +97891,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1298,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -91849,7 +97969,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1299,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -91925,7 +98051,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1300,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -92005,7 +98137,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1301,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -92065,7 +98203,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1302,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -92085,7 +98229,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1302,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -92163,7 +98313,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1303,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92239,7 +98395,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1304,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92313,7 +98475,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1305,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -92368,7 +98536,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1306,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92387,7 +98561,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1306,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92463,7 +98643,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1307,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92520,7 +98706,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1308,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92539,7 +98731,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1308,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92596,7 +98794,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1309,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92615,7 +98819,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1309,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92671,7 +98881,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1310,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -92689,7 +98905,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1310,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -92763,7 +98985,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1311,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92837,7 +99065,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1312,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -92911,7 +99145,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1313,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -92987,7 +99227,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1314,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -93063,7 +99309,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1315,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -93121,7 +99373,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1316,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93141,7 +99399,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1316,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93221,7 +99485,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1317,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93301,7 +99571,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1318,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93361,7 +99637,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1319,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93381,7 +99663,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1319,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93461,7 +99749,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1320,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93541,7 +99835,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1321,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93621,7 +99921,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1322,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93701,7 +100007,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1323,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93781,7 +100093,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1324,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93861,7 +100179,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1325,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -93920,7 +100244,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1326,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -93939,7 +100269,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1326,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18S",
+				"value": 18.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -93996,7 +100332,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1327,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -94015,7 +100357,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1327,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -94072,7 +100420,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1328,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -94091,7 +100445,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1328,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -94149,7 +100509,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1329,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94169,7 +100535,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1329,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19E",
+				"value": 19.1
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94245,7 +100617,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1330,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -94321,7 +100699,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1331,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94381,7 +100765,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1332,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94401,7 +100791,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1332,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94481,7 +100877,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1333,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94561,7 +100963,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1334,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94621,7 +101029,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1335,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94641,7 +101055,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1335,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94721,7 +101141,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1336,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -94797,7 +101223,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1337,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -94871,7 +101303,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1338,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -94945,7 +101383,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1339,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95017,7 +101461,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1340,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95091,7 +101541,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1341,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid"
@@ -95165,7 +101621,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1342,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95219,7 +101681,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1343,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16S",
+				"value": 16.9
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95237,7 +101705,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1343,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95309,7 +101783,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1344,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95383,7 +101863,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1345,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -95440,7 +101926,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1346,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -95459,7 +101951,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1346,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -95535,7 +102033,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1347,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -95611,7 +102115,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1348,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -95689,7 +102199,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1349,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A+ - 18D",
+				"value": 18
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -95765,7 +102281,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1350,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95837,7 +102359,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1351,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95909,7 +102437,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1352,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -95981,7 +102515,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1353,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -96053,7 +102593,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1354,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F-",
+				"value": 17
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -96125,7 +102671,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1355,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -96197,7 +102749,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1356,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -96269,7 +102827,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1357,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -96341,7 +102905,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1358,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -96413,7 +102983,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1359,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -96468,7 +103044,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1360,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -96487,7 +103069,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1360,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -96545,7 +103133,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1361,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96565,7 +103159,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1361,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20B",
+				"value": 20.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96625,7 +103225,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1362,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96645,7 +103251,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1362,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A+",
+				"value": 20.7
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96705,7 +103317,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1363,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96725,7 +103343,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1363,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96785,7 +103409,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1364,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96805,7 +103435,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1364,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96885,7 +103521,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1365,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96945,7 +103587,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1366,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -96965,7 +103613,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1366,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -97045,7 +103699,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1367,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -97105,7 +103765,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1368,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -97125,7 +103791,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1368,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"heaven",
 			"vivid",
@@ -97184,7 +103856,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1369,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97203,7 +103881,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1369,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97260,7 +103944,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1370,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97279,7 +103969,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1370,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97355,7 +104051,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1371,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97431,7 +104133,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1372,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97488,7 +104196,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1373,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97507,7 +104221,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1373,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97564,7 +104284,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1374,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97583,7 +104309,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1374,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97659,7 +104391,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1375,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97716,7 +104454,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1376,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97735,7 +104479,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1376,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97792,7 +104542,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1377,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97811,7 +104567,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1377,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97887,7 +104649,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1378,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97944,7 +104712,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1379,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -97963,7 +104737,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1379,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98020,7 +104800,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1380,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98039,7 +104825,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1380,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98115,7 +104907,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1381,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98191,7 +104989,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1382,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98248,7 +105052,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1383,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98267,7 +105077,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1383,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98343,7 +105159,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1384,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98419,7 +105241,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1385,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98476,7 +105304,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1386,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16S",
+				"value": 16.9
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98495,7 +105329,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1386,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98571,7 +105411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1387,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98647,7 +105493,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1388,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A - 17D",
+				"value": 17
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98704,7 +105556,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1389,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98723,7 +105581,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1389,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98799,7 +105663,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1390,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98875,7 +105745,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1391,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -98951,7 +105827,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1392,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99027,7 +105909,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1393,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99103,7 +105991,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1394,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99179,7 +106073,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1395,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99255,7 +106155,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1396,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18S",
+				"value": 18.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99312,7 +106218,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1397,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99331,7 +106243,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1397,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99407,7 +106325,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1398,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99483,7 +106407,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1399,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99540,7 +106470,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1400,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99559,7 +106495,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1400,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A - 18E",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99635,7 +106577,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1401,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99711,7 +106659,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1402,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99787,7 +106741,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1403,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99863,7 +106823,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1404,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -99939,7 +106905,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1405,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100015,7 +106987,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1406,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100072,7 +107050,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1407,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100091,7 +107075,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1407,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100167,7 +107157,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1408,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100243,7 +107239,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1409,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100319,7 +107321,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1410,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100395,7 +107403,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1411,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100471,7 +107485,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1412,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100547,7 +107567,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1413,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100623,7 +107649,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1414,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100699,7 +107731,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1415,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100775,7 +107813,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1416,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100851,7 +107895,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1417,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100927,7 +107977,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1418,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -100984,7 +108040,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1419,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101003,7 +108065,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1419,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101079,7 +108147,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1420,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101155,7 +108229,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1421,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101231,7 +108311,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1422,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101307,7 +108393,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1423,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101383,7 +108475,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1424,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101459,7 +108557,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1425,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101535,7 +108639,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1426,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101611,7 +108721,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1427,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101687,7 +108803,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1428,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101782,7 +108904,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1429,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101858,7 +108986,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1430,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -101934,7 +109068,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1431,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102010,7 +109150,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1432,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102048,7 +109194,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1433,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102067,7 +109219,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1433,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102124,7 +109282,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1434,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102143,7 +109307,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1434,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102200,7 +109370,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1435,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102219,7 +109395,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1435,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A - 18E",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102295,7 +109477,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1436,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102352,7 +109540,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1437,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102371,7 +109565,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1437,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102519,7 +109719,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1439,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102595,7 +109801,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1440,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102671,7 +109883,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1441,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102747,7 +109965,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1442,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102823,7 +110047,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1443,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102899,7 +110129,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1444,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -102975,7 +110211,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1445,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -103049,7 +110291,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1446,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103121,7 +110369,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1447,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103193,7 +110447,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1448,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103265,7 +110525,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1449,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103337,7 +110603,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1450,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103409,7 +110681,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1451,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103481,7 +110759,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1452,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103553,7 +110837,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1453,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103625,7 +110915,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1454,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103697,7 +110993,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1455,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103769,7 +111071,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1456,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103841,7 +111149,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1457,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103913,7 +111227,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1458,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -103968,7 +111288,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1459,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -103987,7 +111313,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1459,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104044,7 +111376,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1460,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104063,7 +111401,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1460,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104120,7 +111464,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1461,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104139,7 +111489,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1461,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104196,7 +111552,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1462,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104215,7 +111577,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1462,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A",
+				"value": 20.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104272,7 +111640,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1463,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104291,7 +111665,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1463,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104348,7 +111728,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1464,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104367,7 +111753,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1464,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104424,7 +111816,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1465,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104443,7 +111841,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1465,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104519,7 +111923,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1466,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A+ - 18D",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104576,7 +111986,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1467,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104595,7 +112011,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1467,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104671,7 +112093,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1468,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104745,7 +112173,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1469,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -104819,7 +112253,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1472,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104895,7 +112335,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1473,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104952,7 +112398,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1474,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -104971,7 +112423,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1474,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -105028,7 +112486,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1475,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -105047,7 +112511,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1475,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -105123,7 +112593,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1476,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -105179,7 +112655,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1477,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -105197,7 +112679,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1477,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -105251,7 +112739,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1480,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105269,7 +112763,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1480,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105323,7 +112823,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1481,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105341,7 +112847,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1481,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105395,7 +112907,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1482,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105413,7 +112931,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1482,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105467,7 +112991,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1483,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105485,7 +113015,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1483,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105557,7 +113093,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1484,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105611,7 +113153,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1485,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105629,7 +113177,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1485,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18F",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105701,7 +113255,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1486,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105773,7 +113333,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1487,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105845,7 +113411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1488,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -105917,7 +113489,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1489,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -106116,7 +113694,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1495,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18S",
+				"value": 18.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106135,7 +113719,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1495,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A+",
+				"value": 20.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106192,7 +113782,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1496,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106211,7 +113807,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1496,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106287,7 +113889,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1497,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106344,7 +113952,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1498,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106363,7 +113977,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1498,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106439,7 +114059,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1499,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106496,7 +114122,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1500,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106515,7 +114147,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1500,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106572,7 +114210,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1501,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106591,7 +114235,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1501,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106647,7 +114297,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1502,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -106665,7 +114321,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1502,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -106719,7 +114381,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1503,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -106737,7 +114405,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1503,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -106809,7 +114483,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1504,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -106883,7 +114563,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1505,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -106959,7 +114645,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1509,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107035,7 +114727,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1510,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107111,7 +114809,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1514,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107185,7 +114889,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1515,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -107259,7 +114969,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1516,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107335,7 +115051,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1518,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107392,7 +115114,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1519,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107411,7 +115139,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1519,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107468,7 +115202,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1521,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107487,7 +115227,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1521,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107543,7 +115289,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1522,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -107561,7 +115313,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1522,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -107635,7 +115393,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1523,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107692,7 +115456,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1526,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107711,7 +115481,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1526,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107787,7 +115563,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1529,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -107843,7 +115625,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1530,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -107861,7 +115649,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1530,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -107915,7 +115709,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1531,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16F",
+				"value": 16
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -107933,7 +115733,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1531,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -108007,7 +115813,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1532,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108083,7 +115895,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1534,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108140,7 +115958,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1536,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108159,7 +115983,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1536,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108233,7 +116063,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1537,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -108305,7 +116141,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1538,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -108379,7 +116221,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1540,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108455,7 +116303,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1541,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108511,7 +116365,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1542,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -108529,7 +116389,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1542,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -108603,7 +116469,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1543,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F-",
+				"value": 17
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108679,7 +116551,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1544,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108735,7 +116613,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1547,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -108753,7 +116637,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1547,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -108807,7 +116697,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1548,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -108825,7 +116721,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1548,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -108918,7 +116820,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1549,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -108994,7 +116902,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1550,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109067,7 +116981,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1551,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -109142,7 +117062,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1552,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109218,7 +117144,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1553,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109256,7 +117188,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1554,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109294,7 +117232,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1554,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109370,7 +117314,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1555,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109446,7 +117396,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1556,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109522,7 +117478,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1557,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109560,7 +117522,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1558,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109598,7 +117566,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1558,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109674,7 +117648,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1559,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109750,7 +117730,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1560,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109787,7 +117773,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1561,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -109823,7 +117815,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1561,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -109860,7 +117858,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1562,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109898,7 +117902,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1562,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -109974,7 +117984,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1563,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110050,7 +118066,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1564,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110123,7 +118145,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1565,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -110160,7 +118188,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1566,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110198,7 +118232,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1566,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110274,7 +118314,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1567,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110350,7 +118396,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1568,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110426,7 +118478,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1569,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110499,7 +118557,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1570,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -110536,7 +118600,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1571,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110574,7 +118644,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1571,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110647,7 +118723,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1572,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -110722,7 +118804,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1573,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110798,7 +118886,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1574,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110874,7 +118968,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1575,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110950,7 +119050,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1576,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -110988,7 +119094,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1577,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111026,7 +119138,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1577,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111102,7 +119220,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1578,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111140,7 +119264,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1579,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111178,7 +119308,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1579,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111216,7 +119352,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1580,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18A+ - 18C",
+				"value": 18
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111235,7 +119377,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1580,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20S",
+				"value": 20.8
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111292,7 +119440,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1581,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111311,7 +119465,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1581,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111368,7 +119528,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1582,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111387,7 +119553,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1582,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111444,7 +119616,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1583,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111463,7 +119641,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1583,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111520,7 +119704,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1584,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111539,7 +119729,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1584,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A+",
+				"value": 20.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111596,7 +119792,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1585,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111615,7 +119817,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1585,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111672,7 +119880,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1586,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A+",
+				"value": 16.7
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111691,7 +119905,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1586,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111748,7 +119968,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1587,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111767,7 +119993,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1587,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111824,7 +120056,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1588,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111843,7 +120081,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1588,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111919,7 +120163,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1589,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111976,7 +120226,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1590,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -111995,7 +120251,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1590,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112052,7 +120314,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1591,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112071,7 +120339,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1591,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112128,7 +120402,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1592,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112147,7 +120427,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1592,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112204,7 +120490,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1593,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112223,7 +120515,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1593,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112299,7 +120597,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1594,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112375,7 +120679,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1595,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112451,7 +120761,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1596,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112527,7 +120843,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1597,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A+",
+				"value": 17.8
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112584,7 +120906,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1598,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112603,7 +120931,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1598,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112660,7 +120994,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1599,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112679,7 +121019,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1599,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112755,7 +121101,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1600,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112831,7 +121183,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1601,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112888,7 +121246,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1602,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112907,7 +121271,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1602,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -112983,7 +121353,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1603,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113059,7 +121435,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1604,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113135,7 +121517,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1605,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113211,7 +121599,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1606,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113268,7 +121662,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1607,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113287,7 +121687,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1607,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113363,7 +121769,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1608,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113439,7 +121851,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1609,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113496,7 +121914,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1610,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113515,7 +121939,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1610,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113572,7 +122002,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1611,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113591,7 +122027,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1611,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113647,7 +122089,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1612,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -113665,7 +122113,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1612,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -113719,7 +122173,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1613,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -113737,7 +122197,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1613,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -113809,7 +122275,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1614,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -113883,7 +122355,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1615,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -113959,7 +122437,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1616,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114035,7 +122519,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1617,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17A+ - 17E",
+				"value": 17
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114111,7 +122601,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1618,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114168,7 +122664,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1619,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16A/B",
+				"value": 16.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114187,7 +122689,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1619,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A+",
+				"value": 18.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114244,7 +122752,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1620,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114263,7 +122777,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1620,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114337,7 +122857,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1621,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114409,7 +122935,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1622,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114481,7 +123013,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1623,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114553,7 +123091,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1624,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114608,7 +123152,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1625,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114627,7 +123177,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1625,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114701,7 +123257,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1626,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114773,7 +123335,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1627,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114845,7 +123413,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1628,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114917,7 +123491,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1629,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -114972,7 +123552,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1630,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -114991,7 +123577,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1630,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -115047,7 +123639,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1631,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115065,7 +123663,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1631,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115119,7 +123723,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1632,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16F",
+				"value": 16
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115137,7 +123747,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1632,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115209,7 +123825,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1633,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115281,7 +123903,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1638,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115335,7 +123963,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1639,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115353,7 +123987,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1639,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19D",
+				"value": 19.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115425,7 +124065,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1640,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115479,7 +124125,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1641,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115497,7 +124149,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1641,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -115569,7 +124227,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1647,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -115623,7 +124287,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1648,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -115641,7 +124311,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1648,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -115713,7 +124389,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1649,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -115785,7 +124467,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1650,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -115857,7 +124545,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1652,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -115929,7 +124623,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1653,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -115984,7 +124684,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1660,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116003,7 +124709,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1660,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20B",
+				"value": 20.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116060,7 +124772,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1661,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116079,7 +124797,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1661,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116136,7 +124860,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1662,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116155,7 +124885,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1662,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116212,7 +124948,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1663,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116231,7 +124973,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1663,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19S - 19F",
+				"value": 19
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116288,7 +125036,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1664,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116307,7 +125061,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1664,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116364,7 +125124,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1665,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116383,7 +125149,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1665,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116440,7 +125212,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1666,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116459,7 +125237,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1666,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid",
 			"konaste"
@@ -116533,7 +125317,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1668,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -116605,7 +125395,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1669,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -116677,7 +125473,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1670,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -116731,7 +125533,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1671,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16F",
+				"value": 16
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -116749,7 +125557,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1671,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"vivid"
 		]
@@ -116821,7 +125635,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1675,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -116875,7 +125695,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1681,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -116893,7 +125719,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1681,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -116965,7 +125797,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1686,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117019,7 +125857,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1712,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117037,7 +125881,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1712,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18E",
+				"value": 18.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117091,7 +125941,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1713,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117109,7 +125965,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1713,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117163,7 +126025,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1718,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117181,7 +126049,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1718,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117253,7 +126127,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1720,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117325,7 +126205,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1721,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117397,7 +126283,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1723,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117469,7 +126361,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1724,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117541,7 +126439,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1729,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117595,7 +126499,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1734,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117613,7 +126523,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1734,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117667,7 +126583,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1735,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117685,7 +126607,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1735,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18B",
+				"value": 18.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117757,7 +126685,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1753,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117829,7 +126763,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1754,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17B",
+				"value": 17.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117901,7 +126841,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1755,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -117973,7 +126919,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1756,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118045,7 +126997,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1757,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118117,7 +127075,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1758,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118171,7 +127135,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1762,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118189,7 +127159,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1762,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A",
+				"value": 19.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118243,7 +127219,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1763,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118261,7 +127243,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1763,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118315,7 +127303,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1764,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17A",
+				"value": 17.7
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118333,7 +127327,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1764,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19A+",
+				"value": 19.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118387,7 +127387,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1765,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D+",
+				"value": 17.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118405,7 +127411,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1765,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19B",
+				"value": 19.4
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118459,7 +127471,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1811,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18A",
+				"value": 18.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118477,7 +127495,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1811,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "20A",
+				"value": 20.6
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118531,7 +127555,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1812,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": true,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -118549,7 +127579,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1812,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]

--- a/collections/charts-sdvx.json
+++ b/collections/charts-sdvx.json
@@ -117015,7 +117015,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1551,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -124615,7 +124621,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1651,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -124825,7 +124837,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1659,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17E",
+				"value": 17.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -124843,7 +124861,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1659,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "19C",
+				"value": 19.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -127871,7 +127895,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1823,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17F",
+				"value": 17.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -127925,7 +127955,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1824,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16E",
+				"value": 16.1
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -127943,7 +127979,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1824,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18D",
+				"value": 18.2
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -127997,7 +128039,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1825,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "16C/D",
+				"value": 16.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -128015,7 +128063,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1825,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "18C",
+				"value": 18.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -128087,7 +128141,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1826,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17D",
+				"value": 17.3
+			}
+		},
 		"versions": [
 			"konaste"
 		]
@@ -128159,7 +128219,13 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 1827,
-		"tierlistInfo": {},
+		"tierlistInfo": {
+			"clear": {
+				"individualDifference": false,
+				"text": "17C",
+				"value": 17.5
+			}
+		},
 		"versions": [
 			"konaste"
 		]

--- a/scripts/rerunners/add-sdvx-clear-tierlist.js
+++ b/scripts/rerunners/add-sdvx-clear-tierlist.js
@@ -1,0 +1,503 @@
+const { Command } = require("commander");
+const { parse } = require("csv-parse/sync");
+const fs = require("fs");
+const { ReadCollection, MutateCollection } = require("../util");
+
+// The tier lists are available at
+// https://docs.google.com/spreadsheets/d/1cFltguBvPplBem-x1STHnG3k4TZzFfyNEZ-RwsQszoo/edit
+// Download a given level's tierlist as CSV and use -f <CSV filename>.
+// The level number will be picked up from the filename.
+
+const SUPER_INDIV_DIFFERENCE = "超個人差";
+
+const TIERS = {
+	// 16 tiers are really weird for no good reason.
+	16: {
+		"16逆詐称(16F)": {
+			text: "16F",
+			value: 16.0,
+		},
+		"16弱(16EとF)": {
+			text: "16E",
+			value: 16.1,
+		},
+		"16中(16CとD)": {
+			text: "16C/D",
+			value: 16.3,
+		},
+		"16強(16AとB)": {
+			text: "16A/B",
+			value: 16.5,
+		},
+		"16強+(16A以上S未満)": {
+			text: "16A+",
+			value: 16.7,
+		},
+		"16詐称(16S)": {
+			text: "16S",
+			value: 16.9,
+		},
+	},
+	17: {
+		"F-": {
+			text: "17F-",
+			value: 17.0,
+		},
+		"F": {
+			text: "17F",
+			value: 17.1,
+		},
+		"E": {
+			text: "17E",
+			value: 17.2,
+		},
+		"D": {
+			text: "17D",
+			value: 17.3,
+		},
+		"D+": {
+			text: "17D+",
+			value: 17.4,
+		},
+		"C": {
+			text: "17C",
+			value: 17.5,
+		},
+		"B": {
+			text: "17B",
+			value: 17.6,
+		},
+		"A": {
+			text: "17A",
+			value: 17.7,
+		},
+		"A+": {
+			text: "17A+",
+			value: 17.8,
+		},
+		// There is no S, don't ask me why.
+	},
+	18: {
+		"F": {
+			text: "18F",
+			value: 18.0,
+		},
+		"E": {
+			text: "18E",
+			value: 18.1,
+		},
+		"D": {
+			text: "18D",
+			value: 18.2,
+		},
+		"C": {
+			text: "18C",
+			value: 18.3,
+		},
+		"B": {
+			text: "18B",
+			value: 18.4,
+		},
+		"A": {
+			text: "18A",
+			value: 18.5,
+		},
+		"A+": {
+			text: "18A+",
+			value: 18.6,
+		},
+		"S": {
+			text: "18S",
+			value: 18.7,
+		},
+		"SS": {
+			// Literally just Joyeuse lmao
+			text: "18SS",
+			value: 18.9,
+		},
+	},
+	19: {
+		"F": {
+			text: "19F",
+			value: 19.0,
+		},
+		"E": {
+			text: "19E",
+			value: 19.1,
+		},
+		"D": {
+			text: "19D",
+			value: 19.2,
+		},
+		"C": {
+			text: "19C",
+			value: 19.3,
+		},
+		"B": {
+			text: "19B",
+			value: 19.4,
+		},
+		"A": {
+			text: "19A",
+			value: 19.5,
+		},
+		"A+": {
+			text: "19A+",
+			value: 19.6,
+		},
+		"S": {
+			text: "19S",
+			value: 19.7,
+		},
+	},
+	20: {
+		"B": {
+			text: "20B",
+			value: 20.4,
+		},
+		"A": {
+			text: "20A",
+			value: 20.6,
+		},
+		"A+": {
+			text: "20A+",
+			value: 20.7,
+		},
+		"S": {
+			text: "20S",
+			value: 20.8,
+		},
+	},
+};
+
+const MANUAL_TITLE_MAP = {
+	// 16s
+	"jack-the-Ripper♦": "Jack-the-Ripper◆",
+	"50th Memorial Songs-二人の時-": "50th Memorial Songs -二人の時 ～under the cherry blossoms～-",
+	// "Help me, CODYYYYYY!!" is a special title that only applies to the GRV... why, sdvx, why
+	"Help me,CODYYYYYY!!": "Help me, ERINNNNNN!! - SH Style -",
+	"Togather Going My Way": "Together Going My Way", // lol
+	"コンベア速度Maxしゃいにん☆廻転ズシ": "コンベア速度Max!? しゃいにん☆廻転ズシ\"Sushi&Peace\"",
+	"Venomous Firefry": "Venomous Firefly", // you fry them up real good
+	"Genesis At Oasis(Matsudo)": "Genesis At Oasis (Hirayasu Matsudo Remix)",
+	"FIRST:DREAM": "FIRST：DREAMS",
+	"Flaa Behaivor": "Flaa Behavior",
+	"FlwoerNation": "FlowerNation",
+	"けもののおうじゃ めうめう": "けもののおうじゃ🐾めうめう",
+	"すきなことでいいです": "すきなことだけでいいです",
+	"U.N.オーエンは彼女なのか(TO-HOlic)": "U.N.オーエンは彼女なのか？(TO-HOlic mix)",
+	"Elemental Creation(Kamome mix)": "Elemental Creation (kamome sano Remix)",
+	"Engraved Mark -Gow's ill!-": "Engraved Mark-Gow's ill! RMX-",
+	"Make Majic": "Make Magic", // asdf
+	"夏色DIARY -SD'VmiX-": "夏色DIARY -Summer Dazzlin' Vacation miX-",
+	"ユニバーページ(i-word Mix)": "ユニバーページ（i-world Mix）",
+	// In their defence I make this typo all the time
+	"50th Memorial Songs -Begining Story-": "50th Memorial Songs -Beginning Story-",
+	// This is NOT "Game Over". This is an EG chart and isn't in this
+	// repo yet but better to avoid confusion down the line.
+	"GAME ØVER": "G4ME ØVEЯ",
+	"Narcissus At Oasis 影虎。style": "Narcissus At Oasis -影虎。 style-",
+	"POSSESSION (Aoi Q.E.DRMX)": "POSSESSION (Aoi Q.E.D. RMX)",
+	"Narcissus At Oasis (Freezer)": "Narcissus At Oasis (Freezer Remix)",
+	// There are two prefix-matches for this, so we need to be explicit.
+	"RPG": "RPG／アニメ「映画クレヨンしんちゃん バカうまっ！B級グルメサバイバル！！」より",
+	"Applique": "Appliqué",
+	"Daydream Cafê(Euro Hopping Mix)": "Daydream café (Euro Hopping Mix)",
+	"Thank you for playing music": "Thank you for your playing music", // LMFAOOO
+	"赤より紅い夢-Aya2g Tech Dance Rmx-": "赤より紅い夢-Aya2g Tech Dance Remix-",
+	"動く、動く(Electro Remix)": "動く、動く（\"A&M Chillin' \" Electro Remix）",
+	"幻想郷DENPASTICグリーティング": "幻想郷DEMPASTICグリーティング",
+	"雪月花 (Shiron)": "雪月花 (Shiron & Sound Artz Remix)",
+	"闇夜舞踏会 -緋碧と蝶のための-masquerade-": "闇夜舞踏会 -緋碧と蝶のためのmasquerade-",
+	"少年は空を辿る Prog Piano Rmx": "少年は空を辿る Prog Piano Remix",
+	"EOS INFINITE EDIT": "EOS -INFINITE EDIT-",
+	"Now Loading...": "Now loading…",
+	"しゅわスパ大作戦☆(カシオれ！くーにゃん)": "しゅわスパ大作戦☆ (カシオれ！くーにゃんリミックス)",
+	"双翼 Black Wings - SDVX Edit. -": "双翼 - Black Wings - SDVX Edit. -",
+
+	// 17s
+	"Emperors divide": "Emperor's Divide",
+	"TENKAICHI ULTIMATE MEDLEY": "TENKAICHI ULTIMATE BOSSRUSH MEDLEY",
+	"Believe (y)our Wings{V:VID RAYS}": "Believe (y)our Wings {V:IVID RAYS}",
+	"Help me ERINNNNNN!! -Cranky remix-": "Help me, ERINNNNNN!! -Cranky remix-",
+	"おーまい！らぶりー！すうぃーてぃー！だーりん！": "おーまい！らぶりー！すうぃーてぃ！だーりん！",
+	"サヨナラ・ヘヴン(かめりあ`sRMX)": "サヨナラ・ヘヴン （かめりあ's NEKOMATAelectroRMX）",
+	"超超光速スピードスターかなで": "超☆超☆光☆速☆出☆前☆最☆速!!! スピード★スター★かなで", // understandable
+	"熱情のザパデアート": "熱情のサパデアード",
+	"ゆりゆらららゆるゆり大事件 (yuzenリミ)": "ゆりゆららららゆるゆり大事件（yuzen remix）",
+	// I am not changing the parser to account for missing brackets, and this would
+	// need an override anyways. Included the second one in case they fix it later.
+	"Bule Forest (Prog Key Remix)[MXM": "Blue Forest (Prog Keys Remix)",
+	"Bule Forest (Prog Key Remix)": "Blue Forest (Prog Keys Remix)",
+	"チルノとまりおのパーフェクト算数教室": "チルノとまりおのパーフェクトさんすう教室", // I guess???
+	"物凄いｽﾍﾟｰｽｼｬﾄﾙでこいしが物凄いうた": "物凄いスペースシャトルでこいしが物凄いうた", // also not 100% sure
+	"Iridescent Crouds": "Iridescent Clouds", // there's so many people I can't see!
+	"感情の摩天楼～Arr.Demetori": "感情の魔天楼 ～ Arr.Demetori",
+	".59 -BOOTH REMIX-": ".59 -BOOTH BOOST REMIX-",
+	"One In A Billion(Hedonist Rimix)": "One In A Billion（Hedonist Remix）",
+	"cloche(といぼっくすうぃんぐ　りみっくす)": "cloche(といぼっくすうぃんぐ　みっくす)",
+	"Sacrifce Escape: 不条理の模倣による感情と代償": "Sacrifice Escape: 不条理の模倣による感情と代償",
+	"The Sampling Paradise(P*Light)": "The Sampling Paradise (P*Light Remix)",
+	"イゴモヨスのブヨブヨ・スケッチ": "イゴモヨス＝オムルのテーマによるブヨブヨ・スケッチの試み",
+
+	// 18s
+	"*Erm,～ ShockWAVE Syndrome...?": "* Erm, could it be a Spatiotemporal ShockWAVE Syndrome...?",
+	"Idora": "Idola", // I should just normalize out R/L...
+	"KAC 2013 MEDLEY Empress Side": "KAC 2013 ULTIMATE MEDLEY -HISTORIA SOUND VOLTEX- Empress Side",
+	"KAC 2013 MEDLEY Emperor Side": "KAC 2013 ULTIMATE MEDLEY -HISTORIA SOUND VOLTEX- Emperor Side",
+	"She is my wife ミツル子Remixちゃん": "She is my wife すーぱーアイドル☆ミツル子Remixちゃん",
+	"AΩ": "ΑΩ", // they use latin A instead of alpha
+	"Electric Injuly": "Electric Injury", // holy shit dude
+	"Unicorn tail Dustnoxxxx RMX": "Unicorn tail Dustboxxxx RMX",
+	"混乱少女そふらんちゃん!!": "混乱少女♥そふらんちゃん!!",
+	"消失(Hommarju Rremix)": "消失(Hommarju Remix)", // ur supposed to roll the Rr
+	"Sakura Reflection(P*Light Remix)": "Sakura Reflection (P*Light Slayer Remix)",
+	"怪盗Fの台本 ～消えたダイヤの謎～": "怪盗Ｆの台本～消えたダイヤの謎～", // F
+	"アルティメットトゥルース_-Phantasm-": "アルティメットトゥルース -Phantasm-",
+
+	// 19s
+	// See Blue Forest
+	"Cross Fire[MXM": "Cross Fire",
+}
+
+function validTiers(levelNum) {
+	return Object.keys(TIERS[levelNum]) + [SUPER_INDIV_DIFFERENCE];
+}
+
+function normalizeTitle(title) {
+	return title
+		.toLowerCase()
+		.replace(/ /g, "")
+		.replace(/　/g, "")
+		.replace(/ /g, "")
+		.replace(/：/g, ":")
+		.replace(/（/g, "(")
+		.replace(/）/g, ")")
+		.replace(/！/g, "!")
+		.replace(/？/g, "?")
+		.replace(/`/g, "'")
+		.replace(/’/g, "'")
+		.replace(/～/g, "~")
+}
+
+function findSong(songs, title) {
+	// There are two songs called "Life is [Bb]eautiful". Yes, really.
+	// I CANNOT be assed to search both songs by level or case-sensitive.
+	if (title === "Life is beautiful") {
+		return songs.find(song => song.id === 1264);
+	}
+
+	const song = songs.find(song =>
+		normalizeTitle(song.title) === normalizeTitle(title) ||
+		song.title === MANUAL_TITLE_MAP[title]);
+	if (song) {
+		return song
+	}
+
+	// Only do prefix match _after_ trying normal match, since there are some
+	// correct song titles that are also prefixes of other song titles
+	// (e.g. チルノのパーフェクトさんすう教室 and チルノのパーフェクトさんすう教室　⑨周年バージョン
+	// or Elemental Creation and Elemental Creation (kamome sano Remix)).
+	const prefixSong = songs.find(song => normalizeTitle(song.title).startsWith(normalizeTitle(title)));
+	if (prefixSong) {
+		console.log(`Prefix-matched ${title} to ${prefixSong.title}.`);
+	}
+	return prefixSong;
+}
+
+// levelNum: a number 16-20
+// csvData: raw CSV data from the sheet, in a nested list
+// headerRow: the index (0-indexed) of the row with the tier names
+// leftOffset: the index of the first column with tierlist info
+// simple: do not check for double columns or other weird things (19-20)
+function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
+	const songs = ReadCollection("songs-sdvx.json");
+
+	MutateCollection("charts-sdvx.json", (charts) => {
+		let col = leftOffset;
+		let row = headerRow;
+
+		tierLoop:
+		while (col < csvData[headerRow].length) {
+			let tierName = csvData[row][col];
+			if (tierName === "" && col > leftOffset) {
+				// This might be a double column (two columns for the same tier),
+				// so check the cell to the left.
+				tierName = csvData[row][col - 1];
+			}
+			if (!validTiers(levelNum).includes(tierName)) {
+				// We're probably just done.
+				break;
+			}
+			row++;
+
+			const superDiff = tierName === SUPER_INDIV_DIFFERENCE;
+
+			const baseTier = !superDiff ? TIERS[levelNum][tierName] : {
+				text: SUPER_INDIV_DIFFERENCE,
+				value: levelNum,
+			};
+
+			while (row < csvData.length) {
+				let chartString = csvData[row++][col].trim();
+				if (chartString === "") {
+					break;
+				}
+
+				const tier = {
+					...baseTier,
+					individualDifference: superDiff,
+				}
+
+				// A few overrides.
+				// 【Believe (y)our Wings{V:VID RAYS}】[MXM]
+				chartString = chartString.replace(/^【(.+)】(\[[A-Z]{3}\])$/, "【$1$2】")
+				// Star is outside brackets bc fuck you
+				if (chartString === "※【Opium and Purple haze[GRV]】") {
+					tier.individualDifference = true;
+					chartString = "Opium and Purple haze[GRV]"
+				}
+
+				if (superDiff) {
+					// Extract a range to display (e.g. "18A+ - 18D").
+					// The two ～ characters are different and both are in use.
+					let rangeMatch = chartString.match(/^(.+)\((\d{2}.+)[~〜～](\d{2}.+)\)$/);
+					if (!rangeMatch) {
+						// 19s
+						// Yes, there really is no closing paren.
+						rangeMatch = chartString.match(/^【(.+)\((19.+)[〜～](19.+)】$/);
+					}
+
+					// 16s don't have ranges, so if we can't find it, no sweat.
+					if (rangeMatch) {
+						chartString = rangeMatch[1]
+						tier.text = rangeMatch[2] + " - " + rangeMatch[3];
+					} else {
+						console.log(`No range found for individual difference chart ${chartString}.`)
+					}
+				}
+
+				// We don't actually store this but need to get rid of the brackets.
+				const sightreadKillerMatch = chartString.match(/^【(.*?) ?】$/);
+				if (sightreadKillerMatch) {
+					chartString = sightreadKillerMatch[1];
+				}
+
+				const individualDifferenceMatch = chartString.match(/^※(.*)$/);
+				if (individualDifferenceMatch) {
+					tier.individualDifference = true;
+					chartString = individualDifferenceMatch[1];
+				}
+
+				// Not every entry has the diff, but we need it to distinguish between a few charts
+				// (e.g. KHAMEN BREAK) that have two diffs at the same level.
+				const [_, title, difficulty] = chartString.match(/^(.*?)(?:\[([A-Z]{3})\])?$/);
+				if (difficulty && !["NOV", "ADV", "EXH", "MXM", "INF", "GRV", "HVN", "VVD"].includes(difficulty)) {
+					console.log(`Unknown difficulty ${difficulty} for ${title}.`);
+				}
+
+				const song = findSong(songs, title);
+				if (!song) {
+					console.log(`Unable to find song matching ${title}`)
+					continue;
+				}
+
+				let chart = charts.find(chart => chart.songID === song.id && chart.levelNum === levelNum && chart.difficulty === difficulty);
+				if (!chart) {
+					// Sometimes the difficulty is missing, or straight up wrong (e.g. MXM instead of VVD) so just try without.
+					chart = charts.find(chart => chart.songID === song.id && chart.levelNum === levelNum);
+				}
+
+				if (!chart) {
+					console.log("Can't find chart:");
+					console.log(`tierlist title ${title} matches song ${song.title} (${song.id})`);
+					console.log(`at [${difficulty}] ${levelNum}`);
+					continue;
+				}
+				if ("clear" in chart.tierlistInfo && chart.tierlistInfo["clear"].value !== tier.value) {
+					console.log(`Overwriting tier for ${song.title} [${chart.difficulty}]`);
+					console.log(`Old tier ${chart.tierlistInfo["clear"].text} (${chart.tierlistInfo["clear"].value})`)
+					console.log(`New tier ${tier.text} (${tier.value})`)
+				}
+				chart.tierlistInfo["clear"] = tier;
+			}
+
+			if (simple || row >= csvData.length) {
+				row = headerRow;
+				col++;
+				continue tierLoop;
+			}
+
+			while (csvData[row][col] === "") {
+				row++;
+				if (row >= csvData.length) {
+					// Next column.
+					row = headerRow;
+					col++;
+					continue tierLoop;
+				}
+			}
+
+			// If we get here, we have found something at the bottom of the column.
+			const cell = csvData[row][col]
+			if (cell === tierName) {
+				// This signifies the end of the column.
+				row = headerRow;
+				col++;
+				continue tierLoop;
+			}
+			if (validTiers(levelNum).includes(cell)) {
+				console.log(`Found a second tier in column ${col} at row ${row}.`);
+				// There is another tier, here, continue without resetting col.
+				continue tierLoop;
+			}
+
+			// Otherwise, not sure what we found, but just move on to the next column.
+			row = headerRow;
+			col++;
+		}
+
+		return charts;
+	});
+}
+
+
+const program = new Command();
+program.option("-f, --file <CSV File>")
+program.parse(process.argv);
+const options = program.opts();
+
+const csvData = parse(fs.readFileSync(options.file), {});
+
+const levelIndicator = options.file.match(/ - (Lv.*).csv$/);
+if (!levelIndicator) {
+	console.log("Unrecognized filename.");
+}
+switch (levelIndicator[1]) {
+	case "Lv16":
+		addTiers(16, csvData, 1, 1, false);
+		break;
+	case "Lv17":
+		addTiers(17, csvData, 2, 0, false);
+		break;
+	case "Lv18":
+		addTiers(18, csvData, 1, 0, false);
+		break;
+	case "Lv19〜":
+		addTiers(20, csvData, 1, 1, true);
+
+		// Locate start of 19s
+		let header19 = -1;
+		for (rowIdx in csvData) {
+			if (csvData[rowIdx][0] === "Lv19") {
+				header19 = rowIdx;
+				break;
+			}
+		}
+
+		addTiers(19, csvData, header19, 1, true)
+		break;
+	default:
+		console.log("Unrecognized level");
+		break;
+}

--- a/scripts/rerunners/add-sdvx-clear-tierlist.js
+++ b/scripts/rerunners/add-sdvx-clear-tierlist.js
@@ -88,32 +88,32 @@ const TIERS = {
 		},
 		"D": {
 			text: "18D",
-			value: 18.2,
+			value: 18.3,
 		},
 		"C": {
 			text: "18C",
-			value: 18.3,
+			value: 18.5,
 		},
 		"B": {
 			text: "18B",
-			value: 18.4,
+			value: 18.6,
 		},
 		"A": {
 			text: "18A",
-			value: 18.5,
+			value: 18.7,
 		},
 		"A+": {
 			text: "18A+",
-			value: 18.6,
+			value: 18.8,
 		},
 		"S": {
 			text: "18S",
-			value: 18.7,
+			value: 18.9,
 		},
 		"SS": {
 			// Literally just Joyeuse lmao
 			text: "18SS",
-			value: 18.9,
+			value: 19.5, //if this were a score tier list this would be in the 20s
 		},
 	},
 	19: {
@@ -127,45 +127,45 @@ const TIERS = {
 		},
 		"D": {
 			text: "19D",
-			value: 19.2,
+			value: 19.3,
 		},
 		"C": {
 			text: "19C",
-			value: 19.3,
+			value: 19.4,
 		},
 		"B": {
 			text: "19B",
-			value: 19.4,
+			value: 19.5,
 		},
 		"A": {
 			text: "19A",
-			value: 19.5,
+			value: 19.7,
 		},
 		"A+": {
 			text: "19A+",
-			value: 19.6,
+			value: 19.9,
 		},
 		"S": {
 			text: "19S",
-			value: 19.7,
+			value: 20.0,
 		},
 	},
 	20: {
 		"B": {
 			text: "20B",
-			value: 20.4,
+			value: 20.1,
 		},
 		"A": {
 			text: "20A",
-			value: 20.6,
+			value: 20.3,
 		},
 		"A+": {
 			text: "20A+",
-			value: 20.7,
+			value: 20.5,
 		},
 		"S": {
 			text: "20S",
-			value: 20.8,
+			value: 20.5, //666 is the only S and it's literally no harder than anything in A+ clear wise
 		},
 	},
 };

--- a/scripts/rerunners/add-sdvx-clear-tierlist.js
+++ b/scripts/rerunners/add-sdvx-clear-tierlist.js
@@ -189,6 +189,7 @@ const MANUAL_TITLE_MAP = {
 	"Elemental Creation(Kamome mix)": "Elemental Creation (kamome sano Remix)",
 	"Engraved Mark -Gow's ill!-": "Engraved Mark-Gow's ill! RMX-",
 	"Make Majic": "Make Magic", // asdf
+	"PHYCHO+HEROES": "PSYCHO+HEROES",
 	"夏色DIARY -SD'VmiX-": "夏色DIARY -Summer Dazzlin' Vacation miX-",
 	"ユニバーページ(i-word Mix)": "ユニバーページ（i-world Mix）",
 	// In their defence I make this typo all the time
@@ -258,7 +259,14 @@ const MANUAL_TITLE_MAP = {
 	// 19s
 	// See Blue Forest
 	"Cross Fire[MXM": "Cross Fire",
-}
+};
+
+const AUTOMATION_PARADISE_SONGS = [
+	1259,
+	1438,
+	1490,
+	1491,
+];
 
 function validTiers(levelNum) {
 	return Object.keys(TIERS[levelNum]) + [SUPER_INDIV_DIFFERENCE];
@@ -277,7 +285,7 @@ function normalizeTitle(title) {
 		.replace(/？/g, "?")
 		.replace(/`/g, "'")
 		.replace(/’/g, "'")
-		.replace(/～/g, "~")
+		.replace(/～/g, "~");
 }
 
 function findSong(songs, title) {
@@ -291,7 +299,7 @@ function findSong(songs, title) {
 		normalizeTitle(song.title) === normalizeTitle(title) ||
 		song.title === MANUAL_TITLE_MAP[title]);
 	if (song) {
-		return song
+		return song;
 	}
 
 	// Only do prefix match _after_ trying normal match, since there are some
@@ -347,15 +355,15 @@ function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
 				const tier = {
 					...baseTier,
 					individualDifference: superDiff,
-				}
+				};
 
 				// A few overrides.
 				// 【Believe (y)our Wings{V:VID RAYS}】[MXM]
-				chartString = chartString.replace(/^【(.+)】(\[[A-Z]{3}\])$/, "【$1$2】")
+				chartString = chartString.replace(/^【(.+)】(\[[A-Z]{3}\])$/, "【$1$2】");
 				// Star is outside brackets bc fuck you
 				if (chartString === "※【Opium and Purple haze[GRV]】") {
 					tier.individualDifference = true;
-					chartString = "Opium and Purple haze[GRV]"
+					chartString = "Opium and Purple haze[GRV]";
 				}
 
 				if (superDiff) {
@@ -370,10 +378,10 @@ function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
 
 					// 16s don't have ranges, so if we can't find it, no sweat.
 					if (rangeMatch) {
-						chartString = rangeMatch[1]
+						chartString = rangeMatch[1];
 						tier.text = rangeMatch[2] + " - " + rangeMatch[3];
 					} else {
-						console.log(`No range found for individual difference chart ${chartString}.`)
+						console.log(`No range found for individual difference chart ${chartString}.`);
 					}
 				}
 
@@ -398,7 +406,7 @@ function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
 
 				const song = findSong(songs, title);
 				if (!song) {
-					console.log(`Unable to find song matching ${title}`)
+					console.log(`Unable to find song matching ${title}`);
 					continue;
 				}
 
@@ -416,8 +424,8 @@ function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
 				}
 				if ("clear" in chart.tierlistInfo && chart.tierlistInfo["clear"].value !== tier.value) {
 					console.log(`Overwriting tier for ${song.title} [${chart.difficulty}]`);
-					console.log(`Old tier ${chart.tierlistInfo["clear"].text} (${chart.tierlistInfo["clear"].value})`)
-					console.log(`New tier ${tier.text} (${tier.value})`)
+					console.log(`Old tier ${chart.tierlistInfo["clear"].text} (${chart.tierlistInfo["clear"].value})`);
+					console.log(`New tier ${tier.text} (${tier.value})`);
 				}
 				chart.tierlistInfo["clear"] = tier;
 			}
@@ -439,7 +447,7 @@ function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
 			}
 
 			// If we get here, we have found something at the bottom of the column.
-			const cell = csvData[row][col]
+			const cell = csvData[row][col];
 			if (cell === tierName) {
 				// This signifies the end of the column.
 				row = headerRow;
@@ -457,13 +465,25 @@ function addTiers(levelNum, csvData, headerRow, leftOffset, simple) {
 			col++;
 		}
 
+		const missingTiers = charts.filter(chart =>
+			chart.levelNum === levelNum &&
+			!("clear" in chart.tierlistInfo) &&
+			!AUTOMATION_PARADISE_SONGS.includes(chart.songID));
+		if (missingTiers.length > 0) {
+			console.log(`The following lv${levelNum} charts are still missing a tier:`);
+			for (const chart of missingTiers) {
+				const song = songs.find(song => song.id === chart.songID);
+				console.log(`${song.id}: ${song.title} [${chart.difficulty}] (displayVersion: ${song.data.displayVersion})`);
+			}
+		}
+
 		return charts;
 	});
 }
 
 
 const program = new Command();
-program.option("-f, --file <CSV File>")
+program.option("-f, --file <CSV File>");
 program.parse(process.argv);
 const options = program.opts();
 
@@ -495,7 +515,7 @@ switch (levelIndicator[1]) {
 			}
 		}
 
-		addTiers(19, csvData, header19, 1, true)
+		addTiers(19, csvData, header19, 1, true);
 		break;
 	default:
 		console.log("Unrecognized level");


### PR DESCRIPTION
This adds the widely used clear difficulty tierlist for 16-20 from https://docs.google.com/spreadsheets/d/1cFltguBvPplBem-x1STHnG3k4TZzFfyNEZ-RwsQszoo/edit.

Obviously needs changes to tachi-common and stuff to work.