### PR TITLE
add altTitle for ナイト・オブ・ナイツ かめりあ remix

### DIFF
--- a/collections/songs-wacca.json
+++ b/collections/songs-wacca.json
@@ -3055,7 +3055,9 @@
 		"title": "Shiny Memory feat.Yukacco"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"ナイト・オブ・ナイツ (かめりあ’s“ワンス・アポン・ア・ナイト”Remix)"
+		],
 		"artist": "かめりあ",
 		"data": {
 			"artistJP": "カメリア",


### PR DESCRIPTION
This is what's used on the site.

> KTDataNotFound: Cannot find song with title ナイト・オブ・ナイツ (かめりあ’s“ワンス・アポン・ア・ナイト”Remix).

The difference is the quotes.