### PR TITLE
add cloud IX, treat CSV titles as officially correct

### DIFF
--- a/collections/charts-wacca.json
+++ b/collections/charts-wacca.json
@@ -1549,7 +1549,7 @@
 	{
 		"chartID": "d60eac20879de2f749e02d8c36aa226c1f1d4717",
 		"data": {
-			"isHot": false
+			"isHot": true
 		},
 		"difficulty": "EXPERT",
 		"isPrimary": true,
@@ -1566,7 +1566,7 @@
 	{
 		"chartID": "f4bd38d4a9a5a8cc589b0e409c4e1d56c12b4900",
 		"data": {
-			"isHot": false
+			"isHot": true
 		},
 		"difficulty": "HARD",
 		"isPrimary": true,
@@ -1583,7 +1583,7 @@
 	{
 		"chartID": "6633efa8325221bdc884eb0f19454feb81d5d066",
 		"data": {
-			"isHot": false
+			"isHot": true
 		},
 		"difficulty": "NORMAL",
 		"isPrimary": true,
@@ -18184,6 +18184,57 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 350,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "be9aa7d0d5289e4d3ceec959572921c75fcf71e7",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13.6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 351,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "b596170daf333e4686250c8edeaffca010ebe2be",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10.5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 351,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "d7e1af40ad8a4916646a7da373f70db1f131d360",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
 			"reverse"

--- a/collections/songs-wacca.json
+++ b/collections/songs-wacca.json
@@ -13,7 +13,9 @@
 		"title": "ヒトガタ"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"叩ケ　叩ケ　手ェ叩ケ"
+		],
 		"artist": "SIRO",
 		"data": {
 			"artistJP": "シロ",
@@ -3056,18 +3058,18 @@
 	},
 	{
 		"altTitles": [
-			"ナイト・オブ・ナイツ (かめりあ’s“ワンス・アポン・ア・ナイト”Remix)"
+			"ナイト・オブ・ナイツ (かめりあ's\"ワンス・アポン・ア・ナイト\"Remix)"
 		],
 		"artist": "かめりあ",
 		"data": {
 			"artistJP": "カメリア",
 			"displayVersion": "s",
 			"genre": "東方アレンジ",
-			"titleJP": "ナイト・オブ・ナイツ (カメリア&#039;ズ“ワンス・アポン・ア・ナイト”リミックス)"
+			"titleJP": "ナイト・オブ・ナイツ (カメリア'ズ“ワンス・アポン・ア・ナイト”リミックス)"
 		},
 		"id": 236,
 		"searchTerms": [],
-		"title": "ナイト・オブ・ナイツ (かめりあ's\"ワンス・アポン・ア・ナイト\"Remix)"
+		"title": "ナイト・オブ・ナイツ (かめりあ’s“ワンス・アポン・ア・ナイト”Remix)"
 	},
 	{
 		"altTitles": [],
@@ -3642,7 +3644,9 @@
 		"title": "Galaxy Friends"
 	},
 	{
-		"altTitles": [],
+		"altTitles": [
+			"13 DONKEYS"
+		],
 		"artist": "Massive New Krew",
 		"data": {
 			"artistJP": "マッシブニュークルー",
@@ -4550,5 +4554,20 @@
 		"id": 350,
 		"searchTerms": [],
 		"title": "Dimension Hacker"
+	},
+	{
+		"altTitles": [
+			"cloud Ⅸ"
+		],
+		"artist": "NOMA",
+		"data": {
+			"artistJP": "ノマ",
+			"displayVersion": "reverse",
+			"genre": "オリジナル",
+			"titleJP": "クラウドナイン"
+		},
+		"id": 351,
+		"searchTerms": [],
+		"title": "cloud IX"
 	}
 ]


### PR DESCRIPTION
This adds the charts for the new song "cloud IX". Also, since they use some weird unicode character for IX on the music listing site, this prompted me to change how these broken titles are handled. 
The script now treats the title in the CSV as the "correct" title. I have no way to know which one is actually used in the data, but since we are scraping the user score website right now for score import, it makes sense to use whatever the user website uses (which will always match the CSV, since it's coming from a tool designed to work with that site).
To hedge my bets that this is correct, the script is also changed to always add the title from the music list site (https://wacca.marv.jp/music/) as an altTitle.
This results in 4 changes:
- Add an altTitle for "叩ケ 叩ケ 手ェ叩ケ" that uses full-width spaces
- Swap title and altTitle for "ナイト・オブ・ナイツ (かめりあ’s“ワンス・アポン・ア・ナイト”Remix)"
- Add all-caps altTitle for "13 Donkeys"
- Add an altTitle for the new song "cloud IX" which uses the unicode Ⅸ char