### PR TITLE
update wacca script to use better datasource, add new charts

### DIFF
--- a/collections/charts-wacca.json
+++ b/collections/charts-wacca.json
@@ -2091,6 +2091,23 @@
 		]
 	},
 	{
+		"chartID": "cc384f7ac347b46d1b046851c11db6a65476311a",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "INFERNO",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 40,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
 		"chartID": "1aaf04c98b8a276e38acba1645ef04fd0288d94a",
 		"data": {
 			"isHot": true
@@ -15130,6 +15147,23 @@
 		]
 	},
 	{
+		"chartID": "bb12f97e462971858fd9960c020c31d1bf15d27e",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "INFERNO",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14.1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 293,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
 		"chartID": "6997c63907fd1f49cf5b24992fe5b356d72d9270",
 		"data": {
 			"isHot": false
@@ -18337,6 +18371,74 @@
 		"playtype": "Single",
 		"rgcID": null,
 		"songID": 353,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "5443c455fc0088c2f274cd718016bf0aa3fab697",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 354,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "c6e2513a32200f34871478d4d0739291c5f852cd",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "10+",
+		"levelNum": 10.9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 354,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "60517ead875ef3d3a42c600ef78a4c0841a633e5",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "INFERNO",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14.1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 354,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "47c66e40c4a2b8393f805a403990c3245d084d83",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
 			"reverse"

--- a/collections/songs-wacca.json
+++ b/collections/songs-wacca.json
@@ -9,7 +9,9 @@
 			"titleJP": "ヒトガタ"
 		},
 		"id": 1,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hitogata"
+		],
 		"title": "ヒトガタ"
 	},
 	{
@@ -24,7 +26,9 @@
 			"titleJP": "タタケ タタケ テェタタケ"
 		},
 		"id": 2,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tatake Tatake Te-tatake"
+		],
 		"title": "叩ケ 叩ケ 手ェ叩ケ"
 	},
 	{
@@ -37,7 +41,9 @@
 			"titleJP": "ウッセェワ"
 		},
 		"id": 3,
-		"searchTerms": [],
+		"searchTerms": [
+			"Ussee-wa"
+		],
 		"title": "うっせぇわ"
 	},
 	{
@@ -50,7 +56,9 @@
 			"titleJP": "ハナタチニキボウヲ"
 		},
 		"id": 4,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hana Tachi ni Kibou wo"
+		],
 		"title": "花たちに希望を"
 	},
 	{
@@ -76,7 +84,9 @@
 			"titleJP": "コイノムーンライト"
 		},
 		"id": 6,
-		"searchTerms": [],
+		"searchTerms": [
+			"Koi no Moonlight"
+		],
 		"title": "恋のMoonlight"
 	},
 	{
@@ -141,7 +151,9 @@
 			"titleJP": "フンコツサイシンカジノゥ"
 		},
 		"id": 11,
-		"searchTerms": [],
+		"searchTerms": [
+			"Funkotsu-saishin Casino"
+		],
 		"title": "粉骨砕身カジノゥ"
 	},
 	{
@@ -154,7 +166,9 @@
 			"titleJP": "ロシンユウカイ"
 		},
 		"id": 12,
-		"searchTerms": [],
+		"searchTerms": [
+			"Roshin Yuukai"
+		],
 		"title": "炉心融解"
 	},
 	{
@@ -167,7 +181,9 @@
 			"titleJP": "ワールズエンド・ダンスホール"
 		},
 		"id": 13,
-		"searchTerms": [],
+		"searchTerms": [
+			"World's End Dancehall"
+		],
 		"title": "ワールズエンド・ダンスホール"
 	},
 	{
@@ -180,7 +196,9 @@
 			"titleJP": "インフィニティ"
 		},
 		"id": 14,
-		"searchTerms": [],
+		"searchTerms": [
+			"[Infinity (2018Remake)]"
+		],
 		"title": "∞(2018Remake)"
 	},
 	{
@@ -193,7 +211,9 @@
 			"titleJP": "チガウ!!!"
 		},
 		"id": 15,
-		"searchTerms": [],
+		"searchTerms": [
+			"Chigau!!!"
+		],
 		"title": "ちがう!!!"
 	},
 	{
@@ -206,7 +226,9 @@
 			"titleJP": "カイトウエフノシナリオ キエタダイヤノナゾ"
 		},
 		"id": 16,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kaitou F no Daihon(Scenario) -Kieta Diamond no Nazo-"
+		],
 		"title": "怪盗Fの台本（シナリオ）〜消えたダイヤの謎〜"
 	},
 	{
@@ -219,7 +241,9 @@
 			"titleJP": "オネガイダーリン"
 		},
 		"id": 17,
-		"searchTerms": [],
+		"searchTerms": [
+			"Onegai Darling"
+		],
 		"title": "おねがいダーリン"
 	},
 	{
@@ -232,7 +256,9 @@
 			"titleJP": "メニメニマニマニ"
 		},
 		"id": 18,
-		"searchTerms": [],
+		"searchTerms": [
+			"Many Many Money Money"
+		],
 		"title": "メニメニマニマニ"
 	},
 	{
@@ -245,7 +271,9 @@
 			"titleJP": "アオゾラノラプソディ"
 		},
 		"id": 19,
-		"searchTerms": [],
+		"searchTerms": [
+			"Aozora no Rhapsody"
+		],
 		"title": "青空のラプソディ"
 	},
 	{
@@ -258,7 +286,9 @@
 			"titleJP": "マワレ！セツゲツカ"
 		},
 		"id": 20,
-		"searchTerms": [],
+		"searchTerms": [
+			"Maware! Setsugetsuka"
+		],
 		"title": "回レ！雪月花"
 	},
 	{
@@ -297,7 +327,9 @@
 			"titleJP": "デルタコンプレックス"
 		},
 		"id": 23,
-		"searchTerms": [],
+		"searchTerms": [
+			"[DELTA COMPLEX]"
+		],
 		"title": "D3LTA QOMPLEX"
 	},
 	{
@@ -310,7 +342,9 @@
 			"titleJP": "トウメイセイサイ"
 		},
 		"id": 24,
-		"searchTerms": [],
+		"searchTerms": [
+			"Toumei Seisai"
+		],
 		"title": "透明声彩"
 	},
 	{
@@ -349,7 +383,9 @@
 			"titleJP": "トリノコシティ"
 		},
 		"id": 27,
-		"searchTerms": [],
+		"searchTerms": [
+			"Torinoko City"
+		],
 		"title": "トリノコシティ"
 	},
 	{
@@ -375,7 +411,9 @@
 			"titleJP": "ダーリンダンス"
 		},
 		"id": 29,
-		"searchTerms": [],
+		"searchTerms": [
+			"Darling Dance"
+		],
 		"title": "ダーリンダンス"
 	},
 	{
@@ -388,7 +426,9 @@
 			"titleJP": "サマータイムレコード"
 		},
 		"id": 30,
-		"searchTerms": [],
+		"searchTerms": [
+			"Summer-time Record"
+		],
 		"title": "サマータイムレコード"
 	},
 	{
@@ -427,7 +467,9 @@
 			"titleJP": ""
 		},
 		"id": 33,
-		"searchTerms": [],
+		"searchTerms": [
+			"[Color Code]"
+		],
 		"title": "#1f1e33"
 	},
 	{
@@ -453,7 +495,9 @@
 			"titleJP": ""
 		},
 		"id": 35,
-		"searchTerms": [],
+		"searchTerms": [
+			"Saikyou STRONGER"
+		],
 		"title": "最強STRONGER"
 	},
 	{
@@ -518,7 +562,9 @@
 			"titleJP": "オバーチュア"
 		},
 		"id": 40,
-		"searchTerms": [],
+		"searchTerms": [
+			"[Ouverture]"
+		],
 		"title": "Ouvertüre"
 	},
 	{
@@ -570,7 +616,9 @@
 			"titleJP": "チョウマンジラッシュ"
 		},
 		"id": 44,
-		"searchTerms": [],
+		"searchTerms": [
+			"Cho MANJI Rush"
+		],
 		"title": "超MANJIラッシュ"
 	},
 	{
@@ -596,7 +644,9 @@
 			"titleJP": "サンサーラ！"
 		},
 		"id": 46,
-		"searchTerms": [],
+		"searchTerms": [
+			"Samsara!"
+		],
 		"title": "さんさーら！"
 	},
 	{
@@ -674,7 +724,9 @@
 			"titleJP": ""
 		},
 		"id": 52,
-		"searchTerms": [],
+		"searchTerms": [
+			"Solomon Night"
+		],
 		"title": "ソロモン・ナイト"
 	},
 	{
@@ -687,7 +739,9 @@
 			"titleJP": ""
 		},
 		"id": 53,
-		"searchTerms": [],
+		"searchTerms": [
+			"coeur"
+		],
 		"title": "cœur"
 	},
 	{
@@ -700,7 +754,9 @@
 			"titleJP": ""
 		},
 		"id": 54,
-		"searchTerms": [],
+		"searchTerms": [
+			"Watashi wa No 1!"
+		],
 		"title": "私はNo 1！"
 	},
 	{
@@ -752,7 +808,9 @@
 			"titleJP": "ヤケニインザレイン フィーチャリング　コバヤシワタシ"
 		},
 		"id": 58,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yake-ni in the Rain feat. Kobayashi Watashi"
+		],
 		"title": "やけにインザレイン feat. 小林私"
 	},
 	{
@@ -778,7 +836,9 @@
 			"titleJP": "フラッシュアウト"
 		},
 		"id": 60,
-		"searchTerms": [],
+		"searchTerms": [
+			"[FLASH OUT]"
+		],
 		"title": "FLVSH OUT"
 	},
 	{
@@ -817,7 +877,9 @@
 			"titleJP": ""
 		},
 		"id": 63,
-		"searchTerms": [],
+		"searchTerms": [
+			"Guru-guru DJ TURN!!"
+		],
 		"title": "ぐるぐるDJ TURN!!"
 	},
 	{
@@ -843,7 +905,9 @@
 			"titleJP": ""
 		},
 		"id": 65,
-		"searchTerms": [],
+		"searchTerms": [
+			"Denran Countdown"
+		],
 		"title": "電乱★カウントダウン"
 	},
 	{
@@ -869,7 +933,9 @@
 			"titleJP": "エピクロスノニジハモウミエナイ"
 		},
 		"id": 67,
-		"searchTerms": [],
+		"searchTerms": [
+			"Epikouros no Niji wa Mou Mienai"
+		],
 		"title": "エピクロスの虹はもう見えない"
 	},
 	{
@@ -882,7 +948,9 @@
 			"titleJP": "チルノハカクセイサマーデイズ！"
 		},
 		"id": 68,
-		"searchTerms": [],
+		"searchTerms": [
+			"Cirno wa Kakusei Summer Days!"
+		],
 		"title": "チルノは覚醒サマーデイズ！"
 	},
 	{
@@ -895,7 +963,9 @@
 			"titleJP": "ヨジゲンチョウヤクキカン"
 		},
 		"id": 69,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yo-jigen Chouyaku Kikan"
+		],
 		"title": "四次元跳躍機関"
 	},
 	{
@@ -947,7 +1017,9 @@
 			"titleJP": "トリックラッシュトゥーゼロゼロ"
 		},
 		"id": 73,
-		"searchTerms": [],
+		"searchTerms": [
+			"[TRICKLASH 220]"
+		],
 		"title": "TRICKL4SH 220"
 	},
 	{
@@ -986,7 +1058,9 @@
 			"titleJP": "モペモペ"
 		},
 		"id": 76,
-		"searchTerms": [],
+		"searchTerms": [
+			"Mope-mope"
+		],
 		"title": "もぺもぺ"
 	},
 	{
@@ -1012,7 +1086,9 @@
 			"titleJP": "モノスゴイイキオイデケーネガモノスゴイウタ"
 		},
 		"id": 78,
-		"searchTerms": [],
+		"searchTerms": [
+			"Monosugoi Ikioi de Keine ga Monosugoi Uta"
+		],
 		"title": "物凄い勢いでけーねが物凄いうた"
 	},
 	{
@@ -1025,7 +1101,9 @@
 			"titleJP": "カンブデトマッテスグトケル キョウキノウドンゲイン"
 		},
 		"id": 79,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kanbu de Tomatte Sugu Tokeru - Kyouki no Udongein"
+		],
 		"title": "患部で止まってすぐ溶ける ～ 狂気の優曇華院"
 	},
 	{
@@ -1038,7 +1116,9 @@
 			"titleJP": "バレリーコ"
 		},
 		"id": 80,
-		"searchTerms": [],
+		"searchTerms": [
+			"Barerii-ko"
+		],
 		"title": "バレリーコ"
 	},
 	{
@@ -1051,7 +1131,9 @@
 			"titleJP": "フィクサー"
 		},
 		"id": 81,
-		"searchTerms": [],
+		"searchTerms": [
+			"Fixer"
+		],
 		"title": "フィクサー"
 	},
 	{
@@ -1064,7 +1146,9 @@
 			"titleJP": "テレキャスタービーボーイ"
 		},
 		"id": 82,
-		"searchTerms": [],
+		"searchTerms": [
+			"Telecaster B-Boy"
+		],
 		"title": "テレキャスタービーボーイ"
 	},
 	{
@@ -1077,7 +1161,9 @@
 			"titleJP": "ダレカノシンゾウニナレタナラ"
 		},
 		"id": 83,
-		"searchTerms": [],
+		"searchTerms": [
+			"Dareka no Shinzou ni Nareta Nara"
+		],
 		"title": "だれかの心臓になれたなら"
 	},
 	{
@@ -1090,7 +1176,9 @@
 			"titleJP": "ヒジツザイケイジョシタチハドウスリャイイデスカ？"
 		},
 		"id": 84,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hi Jitsuzaikei Joshi Tachi wa Dousurya Iidesuka?"
+		],
 		"title": "非実在系女子たちはどうすりゃいいですか？"
 	},
 	{
@@ -1103,7 +1191,9 @@
 			"titleJP": "ナダメスカシ ネゴシエーション"
 		},
 		"id": 85,
-		"searchTerms": [],
+		"searchTerms": [
+			"Nadame Sukashi Negotiation"
+		],
 		"title": "なだめスかし Negotiation"
 	},
 	{
@@ -1129,7 +1219,9 @@
 			"titleJP": "サクリファイス"
 		},
 		"id": 87,
-		"searchTerms": [],
+		"searchTerms": [
+			"Sacrifice"
+		],
 		"title": "サクリファイス"
 	},
 	{
@@ -1142,7 +1234,9 @@
 			"titleJP": "ロクチョウネントイチヤモノガタリ"
 		},
 		"id": 88,
-		"searchTerms": [],
+		"searchTerms": [
+			"Rokucho-nen to ichiya monogatari"
+		],
 		"title": "六兆年と一夜物語"
 	},
 	{
@@ -1168,7 +1262,9 @@
 			"titleJP": "ホイホイ ゲンソウホロイズム"
 		},
 		"id": 90,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hoi-hoi Gensou Holo-ism"
+		],
 		"title": "ホイホイ☆幻想ホロイズム"
 	},
 	{
@@ -1259,7 +1355,9 @@
 			"titleJP": "シンチョクウォーズ フィーチャリング ビートマリオ"
 		},
 		"id": 97,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shinchoku WARS feat. Beat Mario"
+		],
 		"title": "進捗WARS feat．ビートまりお"
 	},
 	{
@@ -1298,7 +1396,9 @@
 			"titleJP": "ラクシャ"
 		},
 		"id": 100,
-		"searchTerms": [],
+		"searchTerms": [
+			"[Laksha/Laksa]"
+		],
 		"title": "Lhaksha"
 	},
 	{
@@ -1350,7 +1450,9 @@
 			"titleJP": "フリーフォール"
 		},
 		"id": 104,
-		"searchTerms": [],
+		"searchTerms": [
+			"Free Fall"
+		],
 		"title": "フリーフォール"
 	},
 	{
@@ -1363,7 +1465,9 @@
 			"titleJP": "ネコムスメ"
 		},
 		"id": 105,
-		"searchTerms": [],
+		"searchTerms": [
+			"Neko Musume"
+		],
 		"title": "猫娘"
 	},
 	{
@@ -1415,7 +1519,9 @@
 			"titleJP": "フューチャーキャンディ"
 		},
 		"id": 109,
-		"searchTerms": [],
+		"searchTerms": [
+			"[Future Candy]"
+		],
 		"title": "Future Cαndy"
 	},
 	{
@@ -1467,7 +1573,9 @@
 			"titleJP": "ボクラノシックスティーンビットウォーズ"
 		},
 		"id": 113,
-		"searchTerms": [],
+		"searchTerms": [
+			"Bokurano 16bit Sensou"
+		],
 		"title": "ぼくらの16bit戦争"
 	},
 	{
@@ -1480,7 +1588,9 @@
 			"titleJP": "ワールドイズマイン"
 		},
 		"id": 114,
-		"searchTerms": [],
+		"searchTerms": [
+			"World is Mine"
+		],
 		"title": "ワールドイズマイン"
 	},
 	{
@@ -1493,7 +1603,9 @@
 			"titleJP": "シンチョクドウデスカ！"
 		},
 		"id": 115,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shinchoku Doudesu-ka!"
+		],
 		"title": "進捗どうですか！"
 	},
 	{
@@ -1506,7 +1618,9 @@
 			"titleJP": "カクゼツタナトス"
 		},
 		"id": 116,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kakuzetsu Thanatos"
+		],
 		"title": "隔絶≡タナトス"
 	},
 	{
@@ -1519,7 +1633,9 @@
 			"titleJP": "ハゲシコノヨル　サイレントクレイジーナイト"
 		},
 		"id": 117,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hageshi kono yoru -Psylent Crazy Night-"
+		],
 		"title": "はげしこの夜 -Psylent Crazy Night-"
 	},
 	{
@@ -1532,7 +1648,9 @@
 			"titleJP": "コイメタル"
 		},
 		"id": 118,
-		"searchTerms": [],
+		"searchTerms": [
+			"Koi Metal"
+		],
 		"title": "恋メタル"
 	},
 	{
@@ -1558,7 +1676,9 @@
 			"titleJP": "シャカリキ・ファイト・ブンブン"
 		},
 		"id": 120,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shakariki Fight Bun-bun"
+		],
 		"title": "シャカリキ・ファイト・ブンブン"
 	},
 	{
@@ -1584,7 +1704,9 @@
 			"titleJP": "キシンマッドネス 2153"
 		},
 		"id": 122,
-		"searchTerms": [],
+		"searchTerms": [
+			"[KISHIN MADNESS 2153]"
+		],
 		"title": "QiXiN MAdN3ss 2153"
 	},
 	{
@@ -1623,7 +1745,9 @@
 			"titleJP": "グルーヴ・ザ・ハート"
 		},
 		"id": 125,
-		"searchTerms": [],
+		"searchTerms": [
+			"Groove the Heart"
+		],
 		"title": "グルーヴ・ザ・ハート"
 	},
 	{
@@ -1636,7 +1760,9 @@
 			"titleJP": "パニックポップ☆フェスティバル!!!"
 		},
 		"id": 126,
-		"searchTerms": [],
+		"searchTerms": [
+			"Panic Pop Festival!!!"
+		],
 		"title": "パニックポップ☆フェスティバル!!!"
 	},
 	{
@@ -1649,7 +1775,9 @@
 			"titleJP": "カラカクラ"
 		},
 		"id": 127,
-		"searchTerms": [],
+		"searchTerms": [
+			"[KALACAKRA]"
+		],
 		"title": "KALACAKLA"
 	},
 	{
@@ -1662,7 +1790,9 @@
 			"titleJP": "レイブガール"
 		},
 		"id": 128,
-		"searchTerms": [],
+		"searchTerms": [
+			"[RAVEGIRL]"
+		],
 		"title": "RAV#GIRL"
 	},
 	{
@@ -1688,7 +1818,9 @@
 			"titleJP": "ペコミコダイセンソウ"
 		},
 		"id": 130,
-		"searchTerms": [],
+		"searchTerms": [
+			"Peko Miko Daisensou!!"
+		],
 		"title": "ぺこみこ大戦争！！"
 	},
 	{
@@ -1701,7 +1833,9 @@
 			"titleJP": "セイ！ファンファーレ"
 		},
 		"id": 131,
-		"searchTerms": [],
+		"searchTerms": [
+			"Say! Fanfare!"
+		],
 		"title": "Say!ファンファーレ!"
 	},
 	{
@@ -1727,7 +1861,9 @@
 			"titleJP": "ユメミルソラヘ"
 		},
 		"id": 133,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yumemiru sora e"
+		],
 		"title": "夢見る空へ"
 	},
 	{
@@ -1740,7 +1876,9 @@
 			"titleJP": "オネガイマッスル"
 		},
 		"id": 134,
-		"searchTerms": [],
+		"searchTerms": [
+			"Onegai Muscle"
+		],
 		"title": "お願いマッスル"
 	},
 	{
@@ -1753,7 +1891,9 @@
 			"titleJP": "マッチョアネーム"
 		},
 		"id": 135,
-		"searchTerms": [],
+		"searchTerms": [
+			"Macho a Name?"
+		],
 		"title": "マッチョアネーム？"
 	},
 	{
@@ -1792,7 +1932,9 @@
 			"titleJP": "トロピカッ　バケーション"
 		},
 		"id": 138,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tropica' Vacation"
+		],
 		"title": "トロピカッ☆バケーション"
 	},
 	{
@@ -1831,7 +1973,9 @@
 			"titleJP": "シンチョクドウデスカ？"
 		},
 		"id": 141,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shinchoku Doudesu-ka?"
+		],
 		"title": "進捗どうですか？"
 	},
 	{
@@ -1883,7 +2027,9 @@
 			"titleJP": " アスノヨゾラショウカイハン"
 		},
 		"id": 145,
-		"searchTerms": [],
+		"searchTerms": [
+			"Asu no Yozora Shokaihan"
+		],
 		"title": "アスノヨゾラ哨戒班"
 	},
 	{
@@ -1896,7 +2042,9 @@
 			"titleJP": "ヒビカセ"
 		},
 		"id": 146,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hibikase"
+		],
 		"title": "ヒビカセ"
 	},
 	{
@@ -1909,7 +2057,9 @@
 			"titleJP": "ノウショウサクレツガール"
 		},
 		"id": 147,
-		"searchTerms": [],
+		"searchTerms": [
+			"Noushou Sakuretsu Girl"
+		],
 		"title": "脳漿炸裂ガール"
 	},
 	{
@@ -1935,7 +2085,9 @@
 			"titleJP": "ビョウシンヲカム"
 		},
 		"id": 149,
-		"searchTerms": [],
+		"searchTerms": [
+			"Byoushin wo Kamu"
+		],
 		"title": "秒針を噛む"
 	},
 	{
@@ -1948,7 +2100,9 @@
 			"titleJP": "ナイモノネダリ"
 		},
 		"id": 150,
-		"searchTerms": [],
+		"searchTerms": [
+			"Naimono-nedari"
+		],
 		"title": "ないものねだり"
 	},
 	{
@@ -1987,7 +2141,9 @@
 			"titleJP": "ガヴリールドロップキック"
 		},
 		"id": 153,
-		"searchTerms": [],
+		"searchTerms": [
+			"Gabriel Drop Kick"
+		],
 		"title": "ガヴリールドロップキック"
 	},
 	{
@@ -2013,7 +2169,9 @@
 			"titleJP": "キラメキライダー"
 		},
 		"id": 155,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kirameki Rider"
+		],
 		"title": "キラメキライダー☆"
 	},
 	{
@@ -2052,7 +2210,9 @@
 			"titleJP": "キラットスタート ウサオリミックス"
 		},
 		"id": 158,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kira-tto Start (USAO Remix)"
+		],
 		"title": "キラッとスタート (USAO Remix)"
 	},
 	{
@@ -2065,7 +2225,9 @@
 			"titleJP": "キラットスタート"
 		},
 		"id": 159,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kira-tto Start"
+		],
 		"title": "キラッとスタート"
 	},
 	{
@@ -2078,7 +2240,9 @@
 			"titleJP": "ハート イロ トリドリ～ム"
 		},
 		"id": 160,
-		"searchTerms": [],
+		"searchTerms": [
+			"Heart Iro Tori Dream"
+		],
 		"title": "ハート♥イロ♥トリドリ〜ム"
 	},
 	{
@@ -2091,7 +2255,9 @@
 			"titleJP": "サンキューミュージック"
 		},
 		"id": 161,
-		"searchTerms": [],
+		"searchTerms": [
+			"39 music!"
+		],
 		"title": "39みゅーじっく！"
 	},
 	{
@@ -2104,7 +2270,9 @@
 			"titleJP": "ポジティブダンスタイム"
 		},
 		"id": 162,
-		"searchTerms": [],
+		"searchTerms": [
+			"Positive Dance-Time"
+		],
 		"title": "ポジティブ☆ダンスタイム"
 	},
 	{
@@ -2117,7 +2285,9 @@
 			"titleJP": "ギミギミ フィーチャリング ハツネミク カガミネリン"
 		},
 		"id": 163,
-		"searchTerms": [],
+		"searchTerms": [
+			"Gimme-Gimme feat. Hatsune Miku & Kagamine Rin"
+		],
 		"title": "Gimme×Gimme feat. 初音ミク・鏡音リン"
 	},
 	{
@@ -2130,7 +2300,9 @@
 			"titleJP": "ブリキノダンス"
 		},
 		"id": 164,
-		"searchTerms": [],
+		"searchTerms": [
+			"Buriki no Dance"
+		],
 		"title": "ブリキノダンス"
 	},
 	{
@@ -2143,7 +2315,9 @@
 			"titleJP": "アケボシロケット"
 		},
 		"id": 165,
-		"searchTerms": [],
+		"searchTerms": [
+			"Myoujyou Rocket"
+		],
 		"title": "明星ロケット"
 	},
 	{
@@ -2156,7 +2330,9 @@
 			"titleJP": "ユケムリタマオンセン ツー"
 		},
 		"id": 166,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yukemuri Tama-onsen II"
+		],
 		"title": "ゆけむり魂温泉 II"
 	},
 	{
@@ -2182,7 +2358,9 @@
 			"titleJP": "インドアケイナラトラックメイカー"
 		},
 		"id": 168,
-		"searchTerms": [],
+		"searchTerms": [
+			"Indoor-kei nara Trackmaker"
+		],
 		"title": "インドア系ならトラックメイカー"
 	},
 	{
@@ -2195,7 +2373,9 @@
 			"titleJP": "ニュー・ウェーブ"
 		},
 		"id": 169,
-		"searchTerms": [],
+		"searchTerms": [
+			"New Wave"
+		],
 		"title": "ニュー・ウェーブ"
 	},
 	{
@@ -2325,7 +2505,9 @@
 			"titleJP": "ダンシング サムライ"
 		},
 		"id": 179,
-		"searchTerms": [],
+		"searchTerms": [
+			"Dancing Samurai"
+		],
 		"title": "ダンシング☆サムライ"
 	},
 	{
@@ -2338,7 +2520,9 @@
 			"titleJP": "ダダダダテンシ"
 		},
 		"id": 180,
-		"searchTerms": [],
+		"searchTerms": [
+			"Da Da Da Da-tenshi"
+		],
 		"title": "ダダダダ天使"
 	},
 	{
@@ -2364,7 +2548,9 @@
 			"titleJP": "マジカルガール・メガ・ストライク！"
 		},
 		"id": 182,
-		"searchTerms": [],
+		"searchTerms": [
+			"[MAGiCALGiRL MEGA STRiKE!]"
+		],
 		"title": "MAGiC4LG1RL M3GA S7R1KE!"
 	},
 	{
@@ -2403,7 +2589,9 @@
 			"titleJP": "テンシコウリン"
 		},
 		"id": 185,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tenshi Korin"
+		],
 		"title": "天使光輪"
 	},
 	{
@@ -2429,7 +2617,9 @@
 			"titleJP": "ツアー・ファイナル"
 		},
 		"id": 187,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tour Final"
+		],
 		"title": "ツアー・ファイナル"
 	},
 	{
@@ -2442,7 +2632,9 @@
 			"titleJP": "リアルハツネミクノショウシツ"
 		},
 		"id": 188,
-		"searchTerms": [],
+		"searchTerms": [
+			"Real Hatsune Miku no Shoushitsu"
+		],
 		"title": "リアル初音ミクの消失"
 	},
 	{
@@ -2455,7 +2647,9 @@
 			"titleJP": "ベノム"
 		},
 		"id": 189,
-		"searchTerms": [],
+		"searchTerms": [
+			"Venom"
+		],
 		"title": "ベノム"
 	},
 	{
@@ -2468,7 +2662,9 @@
 			"titleJP": "オバケノウケネライ"
 		},
 		"id": 190,
-		"searchTerms": [],
+		"searchTerms": [
+			"Obake no Uke-nerai"
+		],
 		"title": "おばけのウケねらい"
 	},
 	{
@@ -2481,7 +2677,9 @@
 			"titleJP": "チュルリラ・チュルリラ・ダッダッダ！"
 		},
 		"id": 191,
-		"searchTerms": [],
+		"searchTerms": [
+			"Chururira Chururira Da-da-da!"
+		],
 		"title": "チュルリラ・チュルリラ・ダッダッダ！"
 	},
 	{
@@ -2494,7 +2692,9 @@
 			"titleJP": "デタラメナマイナストプラスニオケルブレンドコウ"
 		},
 		"id": 192,
-		"searchTerms": [],
+		"searchTerms": [
+			"DETARAME NA minus TO plus NI OKERU blend KO"
+		],
 		"title": "デタラメなマイナスとプラスにおけるブレンド考"
 	},
 	{
@@ -2507,7 +2707,9 @@
 			"titleJP": "ボナペティートエス"
 		},
 		"id": 193,
-		"searchTerms": [],
+		"searchTerms": [
+			"Bon Appetit S"
+		],
 		"title": "ぼなぺてぃーと♡S"
 	},
 	{
@@ -2533,7 +2735,9 @@
 			"titleJP": "スマイル・アンド・ティアズ"
 		},
 		"id": 195,
-		"searchTerms": [],
+		"searchTerms": [
+			"Smile and Tears"
+		],
 		"title": "スマイル・アンド・ティアズ"
 	},
 	{
@@ -2546,7 +2750,9 @@
 			"titleJP": "ガンガン・ドンドン"
 		},
 		"id": 196,
-		"searchTerms": [],
+		"searchTerms": [
+			"Gan-gan Don-don"
+		],
 		"title": "ガンガン・ドンドン"
 	},
 	{
@@ -2585,7 +2791,9 @@
 			"titleJP": "サイクルヒット"
 		},
 		"id": 199,
-		"searchTerms": [],
+		"searchTerms": [
+			"Cycle Hit"
+		],
 		"title": "サイクルヒット"
 	},
 	{
@@ -2598,7 +2806,9 @@
 			"titleJP": "セイジャノコドウ"
 		},
 		"id": 200,
-		"searchTerms": [],
+		"searchTerms": [
+			"Seija no Kodo"
+		],
 		"title": "聖者の鼓動"
 	},
 	{
@@ -2637,7 +2847,9 @@
 			"titleJP": "キミノスターライトロード"
 		},
 		"id": 203,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kimi no Starlight Road"
+		],
 		"title": "君のStarlight Road"
 	},
 	{
@@ -2689,7 +2901,9 @@
 			"titleJP": "リンネテンセイ"
 		},
 		"id": 207,
-		"searchTerms": [],
+		"searchTerms": [
+			"Rinne-tensho"
+		],
 		"title": "輪廻転生"
 	},
 	{
@@ -2702,7 +2916,9 @@
 			"titleJP": "ストライク・ザ・ブラッド"
 		},
 		"id": 208,
-		"searchTerms": [],
+		"searchTerms": [
+			"Strike the blood"
+		],
 		"title": "ストライク・ザ・ブラッド"
 	},
 	{
@@ -2741,7 +2957,9 @@
 			"titleJP": "カゼニノセタネガイ"
 		},
 		"id": 211,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kaze ni Noseta Negai"
+		],
 		"title": "風に乗せた願い"
 	},
 	{
@@ -2767,7 +2985,9 @@
 			"titleJP": "ケロキュウディスティニー"
 		},
 		"id": 213,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kero 9 Destiny"
+		],
 		"title": "ケロ⑨Destiny"
 	},
 	{
@@ -2780,7 +3000,9 @@
 			"titleJP": "テングノオトシブミ フィーチャリング ユトリ"
 		},
 		"id": 214,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tengu no Otoshi-bumi feat. ytr"
+		],
 		"title": "天狗の落とし文 feat. ytr"
 	},
 	{
@@ -2793,7 +3015,9 @@
 			"titleJP": "カンサビ"
 		},
 		"id": 215,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shinjaku"
+		],
 		"title": "神寂"
 	},
 	{
@@ -2806,7 +3030,9 @@
 			"titleJP": "アマノジャク"
 		},
 		"id": 216,
-		"searchTerms": [],
+		"searchTerms": [
+			"Amanojaku"
+		],
 		"title": "天ノ弱"
 	},
 	{
@@ -2819,7 +3045,9 @@
 			"titleJP": "セツナトリップ"
 		},
 		"id": 217,
-		"searchTerms": [],
+		"searchTerms": [
+			"Setsuna Trip"
+		],
 		"title": "セツナトリップ"
 	},
 	{
@@ -2832,7 +3060,9 @@
 			"titleJP": "カゲロウデイズ"
 		},
 		"id": 218,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kagerou Daze"
+		],
 		"title": "カゲロウデイズ"
 	},
 	{
@@ -2845,7 +3075,9 @@
 			"titleJP": "シンタカラジマ"
 		},
 		"id": 219,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shin Takarajima"
+		],
 		"title": "新宝島"
 	},
 	{
@@ -2910,7 +3142,9 @@
 			"titleJP": "ベースラインヤッテル?"
 		},
 		"id": 224,
-		"searchTerms": [],
+		"searchTerms": [
+			"Bass-line Yatteru? LOL"
+		],
 		"title": "ベースラインやってる？笑"
 	},
 	{
@@ -2936,7 +3170,9 @@
 			"titleJP": "シャルル"
 		},
 		"id": 226,
-		"searchTerms": [],
+		"searchTerms": [
+			"Charles"
+		],
 		"title": "シャルル"
 	},
 	{
@@ -2975,7 +3211,9 @@
 			"titleJP": "ドラマツルギー"
 		},
 		"id": 229,
-		"searchTerms": [],
+		"searchTerms": [
+			"Dramaturgy"
+		],
 		"title": "ドラマツルギー"
 	},
 	{
@@ -2988,7 +3226,9 @@
 			"titleJP": "ゴーストルール"
 		},
 		"id": 230,
-		"searchTerms": [],
+		"searchTerms": [
+			"Ghost Rule"
+		],
 		"title": "ゴーストルール"
 	},
 	{
@@ -3001,7 +3241,9 @@
 			"titleJP": "イラズラセンセーション"
 		},
 		"id": 231,
-		"searchTerms": [],
+		"searchTerms": [
+			"Itazura Sensation"
+		],
 		"title": "悪戯センセーション"
 	},
 	{
@@ -3014,7 +3256,9 @@
 			"titleJP": "オドループ"
 		},
 		"id": 232,
-		"searchTerms": [],
+		"searchTerms": [
+			"OddLoop"
+		],
 		"title": "オドループ"
 	},
 	{
@@ -3027,7 +3271,9 @@
 			"titleJP": "イーアルファンクラブ"
 		},
 		"id": 233,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yi Er Fanclub"
+		],
 		"title": "いーあるふぁんくらぶ"
 	},
 	{
@@ -3068,7 +3314,9 @@
 			"titleJP": "ナイト・オブ・ナイツ (カメリア'ズ“ワンス・アポン・ア・ナイト”リミックス)"
 		},
 		"id": 236,
-		"searchTerms": [],
+		"searchTerms": [
+			"Night/Knight of Nights/Knights (Kameria's Once-Upon-A-Night Remix)"
+		],
 		"title": "ナイト・オブ・ナイツ (かめりあ’s“ワンス・アポン・ア・ナイト”Remix)"
 	},
 	{
@@ -3081,7 +3329,9 @@
 			"titleJP": "リンネ"
 		},
 		"id": 237,
-		"searchTerms": [],
+		"searchTerms": [
+			"Rinne"
+		],
 		"title": "燐廻"
 	},
 	{
@@ -3133,7 +3383,9 @@
 			"titleJP": "ロストワンノゴウコク"
 		},
 		"id": 241,
-		"searchTerms": [],
+		"searchTerms": [
+			"Lost One no Goukoku"
+		],
 		"title": "ロストワンの号哭"
 	},
 	{
@@ -3172,7 +3424,9 @@
 			"titleJP": "ブラストビート"
 		},
 		"id": 244,
-		"searchTerms": [],
+		"searchTerms": [
+			"[BLAST BEAT]"
+		],
 		"title": "BLVST BEVT"
 	},
 	{
@@ -3198,7 +3452,9 @@
 			"titleJP": "イェーガーマイスター"
 		},
 		"id": 246,
-		"searchTerms": [],
+		"searchTerms": [
+			"[Jagermeister]"
+		],
 		"title": "Jägermeister"
 	},
 	{
@@ -3237,7 +3493,9 @@
 			"titleJP": "エキセントリックショウネンボウイノテーマ"
 		},
 		"id": 249,
-		"searchTerms": [],
+		"searchTerms": [
+			"'Eccentric Shonen Boy' no Theme"
+		],
 		"title": "『エキセントリック少年ボウイ』のテーマ"
 	},
 	{
@@ -3276,7 +3534,9 @@
 			"titleJP": "ハツネミクノショウシツ"
 		},
 		"id": 252,
-		"searchTerms": [],
+		"searchTerms": [
+			"Hatsune Miku no Shoshitsu"
+		],
 		"title": "初音ミクの消失"
 	},
 	{
@@ -3302,7 +3562,9 @@
 			"titleJP": "レットウジョウトウ"
 		},
 		"id": 254,
-		"searchTerms": [],
+		"searchTerms": [
+			"Rettou Joutou"
+		],
 		"title": "劣等上等"
 	},
 	{
@@ -3367,7 +3629,9 @@
 			"titleJP": "タダキミニハレ"
 		},
 		"id": 259,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tada Kimi ni Hare"
+		],
 		"title": "ただ君に晴れ"
 	},
 	{
@@ -3380,7 +3644,9 @@
 			"titleJP": "ザンコクナテンシノテーゼ"
 		},
 		"id": 260,
-		"searchTerms": [],
+		"searchTerms": [
+			"Zankoku na Tenshi no Thesis"
+		],
 		"title": "残酷な天使のテーゼ"
 	},
 	{
@@ -3445,7 +3711,9 @@
 			"titleJP": "アイアイアイ フィーチャリング ナカタヤスタカ"
 		},
 		"id": 265,
-		"searchTerms": [],
+		"searchTerms": [
+			"AIAIAI (feat. Nakata Yasutaka)"
+		],
 		"title": "AIAIAI (feat. 中田ヤスタカ)"
 	},
 	{
@@ -3471,7 +3739,9 @@
 			"titleJP": "マチビトハコズ"
 		},
 		"id": 267,
-		"searchTerms": [],
+		"searchTerms": [
+			"Machi-bito wa Kozu."
+		],
 		"title": "待チ人ハ来ズ。"
 	},
 	{
@@ -3484,7 +3754,9 @@
 			"titleJP": "シュウケツノハナバナ"
 		},
 		"id": 268,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shuketsu no Hanabana"
+		],
 		"title": "集結の華々"
 	},
 	{
@@ -3497,7 +3769,9 @@
 			"titleJP": "チルノノパーフェクトサンスウキョウシツ"
 		},
 		"id": 269,
-		"searchTerms": [],
+		"searchTerms": [
+			"Cirno no Perfect Sansuu Kyoshitsu"
+		],
 		"title": "チルノのパーフェクトさんすう教室"
 	},
 	{
@@ -3549,7 +3823,9 @@
 			"titleJP": "ナイト・オブ・ナイツ"
 		},
 		"id": 273,
-		"searchTerms": [],
+		"searchTerms": [
+			"Night/Knight of Nights/Knights"
+		],
 		"title": "ナイト・オブ・ナイツ"
 	},
 	{
@@ -3588,7 +3864,9 @@
 			"titleJP": "アカリガヤッテキタゾッ"
 		},
 		"id": 276,
-		"searchTerms": [],
+		"searchTerms": [
+			"Akari ga Yatte Kita-zo!"
+		],
 		"title": "アカリがやってきたぞっ"
 	},
 	{
@@ -3614,7 +3892,9 @@
 			"titleJP": "キマグレメルシィフィーチャリングハツネミク"
 		},
 		"id": 278,
-		"searchTerms": [],
+		"searchTerms": [
+			"Kimagure Mercy"
+		],
 		"title": "気まぐれメルシィ feat. 初音ミク"
 	},
 	{
@@ -3627,7 +3907,9 @@
 			"titleJP": "タイヨウケイデスコ"
 		},
 		"id": 279,
-		"searchTerms": [],
+		"searchTerms": [
+			"Taiyou-kei Disco"
+		],
 		"title": "太陽系デスコ"
 	},
 	{
@@ -3668,7 +3950,9 @@
 			"titleJP": "アタラクシア"
 		},
 		"id": 282,
-		"searchTerms": [],
+		"searchTerms": [
+			"[ATARAXiA]"
+		],
 		"title": "ATARAX1A"
 	},
 	{
@@ -3733,7 +4017,9 @@
 			"titleJP": "シアワセニナレルカクシコマンドガアルラシイ"
 		},
 		"id": 287,
-		"searchTerms": [],
+		"searchTerms": [
+			"Shiawase ni Nareru Kakushi Command ga Aru Rashii"
+		],
 		"title": "幸せになれる隠しコマンドがあるらしい"
 	},
 	{
@@ -3772,7 +4058,9 @@
 			"titleJP": "ボクノユメ メチャクソムゲンワキ"
 		},
 		"id": 290,
-		"searchTerms": [],
+		"searchTerms": [
+			"Boku no Yume, Mechakuso Mugen Waki"
+		],
 		"title": "ぼくの夢、メチャクソ無限湧き"
 	},
 	{
@@ -3785,7 +4073,9 @@
 			"titleJP": "コンニチハ アルファデス"
 		},
 		"id": 291,
-		"searchTerms": [],
+		"searchTerms": [
+			"Konnichi wa, ARuFa desu."
+		],
 		"title": "こんにちは、ARuFaです。"
 	},
 	{
@@ -3863,7 +4153,9 @@
 			"titleJP": "スクランブルコウサイ"
 		},
 		"id": 297,
-		"searchTerms": [],
+		"searchTerms": [
+			"Scramble Kousai"
+		],
 		"title": "スクランブル交際"
 	},
 	{
@@ -3876,7 +4168,9 @@
 			"titleJP": "オトメカイボウ"
 		},
 		"id": 298,
-		"searchTerms": [],
+		"searchTerms": [
+			"Otome Kaibou"
+		],
 		"title": "乙女解剖"
 	},
 	{
@@ -3889,7 +4183,9 @@
 			"titleJP": "ファットシテトウゲンキョウ"
 		},
 		"id": 299,
-		"searchTerms": [],
+		"searchTerms": [
+			"Fatto-shite Tougenkyou"
+		],
 		"title": "ファッとして桃源郷"
 	},
 	{
@@ -3902,7 +4198,9 @@
 			"titleJP": "ゲームオーバー(フィーチャリング トリエナ)"
 		},
 		"id": 300,
-		"searchTerms": [],
+		"searchTerms": [
+			"Game Over (feat. TORIENA)"
+		],
 		"title": "ゲームオーバー (feat. TORIENA)"
 	},
 	{
@@ -3915,7 +4213,9 @@
 			"titleJP": "ゴトウブンノキモチ"
 		},
 		"id": 301,
-		"searchTerms": [],
+		"searchTerms": [
+			"Gotoubun no Kimochi"
+		],
 		"title": "五等分の気持ち"
 	},
 	{
@@ -3967,7 +4267,9 @@
 			"titleJP": "ブルースカイ フィーチャリング ノミヤアユミ"
 		},
 		"id": 305,
-		"searchTerms": [],
+		"searchTerms": [
+			"BLUE SKY feat. Nomiya Ayumi"
+		],
 		"title": "BLUE SKY feat. 野宮あゆみ"
 	},
 	{
@@ -4110,7 +4412,9 @@
 			"titleJP": "レーヴァテイン　フィーチャリング　ノミヤアユミ"
 		},
 		"id": 316,
-		"searchTerms": [],
+		"searchTerms": [
+			"LEVATEiN feat. Nomiya Ayumi"
+		],
 		"title": "LEVATEiN feat. 野宮あゆみ"
 	},
 	{
@@ -4123,7 +4427,9 @@
 			"titleJP": "ルーンファクトリーフォースペシャルヨリ コノオモイヲノセテ"
 		},
 		"id": 317,
-		"searchTerms": [],
+		"searchTerms": [
+			"'Kono Omoi wo Nosete' from Rune Factory 4 Special"
+		],
 		"title": "ルーンファクトリー４スペシャルより「この想いを乗せて」"
 	},
 	{
@@ -4136,7 +4442,9 @@
 			"titleJP": "フラジール"
 		},
 		"id": 318,
-		"searchTerms": [],
+		"searchTerms": [
+			"Fragile"
+		],
 		"title": "フラジール"
 	},
 	{
@@ -4149,7 +4457,9 @@
 			"titleJP": "セヤナ ナンデモイウコトヲキイテクレルアカネチャン"
 		},
 		"id": 319,
-		"searchTerms": [],
+		"searchTerms": [
+			"Seyana. - Nandemo Iukoto wo Kiite Kureru Akane-chan -"
+		],
 		"title": "Seyana. ～何でも言うことを聞いてくれるアカネチャン～"
 	},
 	{
@@ -4162,7 +4472,9 @@
 			"titleJP": "ウミユリカイテイタン"
 		},
 		"id": 320,
-		"searchTerms": [],
+		"searchTerms": [
+			"Umiyuri Kaitei-tan"
+		],
 		"title": "ウミユリ海底譚"
 	},
 	{
@@ -4175,7 +4487,9 @@
 			"titleJP": "ギミチョコ"
 		},
 		"id": 321,
-		"searchTerms": [],
+		"searchTerms": [
+			"Gimme Choco!!"
+		],
 		"title": "ギミチョコ!!"
 	},
 	{
@@ -4188,7 +4502,9 @@
 			"titleJP": "ウマーベラス"
 		},
 		"id": 322,
-		"searchTerms": [],
+		"searchTerms": [
+			"U-marvelous"
+		],
 		"title": "ウマーベラス"
 	},
 	{
@@ -4201,7 +4517,9 @@
 			"titleJP": "ロキ"
 		},
 		"id": 323,
-		"searchTerms": [],
+		"searchTerms": [
+			"Roki"
+		],
 		"title": "ロキ"
 	},
 	{
@@ -4214,7 +4532,9 @@
 			"titleJP": "ヨウコソジャパリパークヘ"
 		},
 		"id": 324,
-		"searchTerms": [],
+		"searchTerms": [
+			"Youkoso Japari-Park e"
+		],
 		"title": "ようこそジャパリパークへ"
 	},
 	{
@@ -4240,7 +4560,9 @@
 			"titleJP": "アダバナネクロマンシー"
 		},
 		"id": 326,
-		"searchTerms": [],
+		"searchTerms": [
+			"Adabana Necromancy"
+		],
 		"title": "徒花ネクロマンシー"
 	},
 	{
@@ -4266,7 +4588,9 @@
 			"titleJP": "マトリョシカ"
 		},
 		"id": 328,
-		"searchTerms": [],
+		"searchTerms": [
+			"Matryoshka"
+		],
 		"title": "マトリョシカ"
 	},
 	{
@@ -4279,7 +4603,9 @@
 			"titleJP": "スナノワクセイ フィーチャリング ハツネミク"
 		},
 		"id": 329,
-		"searchTerms": [],
+		"searchTerms": [
+			"Suna no Wakusei feat. Hatsune Miku"
+		],
 		"title": "砂の惑星 feat. 初音ミク"
 	},
 	{
@@ -4292,7 +4618,9 @@
 			"titleJP": "エイリアンエイリアン"
 		},
 		"id": 330,
-		"searchTerms": [],
+		"searchTerms": [
+			"Alien Alien"
+		],
 		"title": "エイリアンエイリアン"
 	},
 	{
@@ -4331,7 +4659,9 @@
 			"titleJP": "ファティマ"
 		},
 		"id": 333,
-		"searchTerms": [],
+		"searchTerms": [
+			"Fatima"
+		],
 		"title": "ファティマ"
 	},
 	{
@@ -4370,7 +4700,9 @@
 			"titleJP": "ピースサイン"
 		},
 		"id": 336,
-		"searchTerms": [],
+		"searchTerms": [
+			"Peace Sign"
+		],
 		"title": "ピースサイン"
 	},
 	{
@@ -4383,7 +4715,9 @@
 			"titleJP": "センボンザクラ"
 		},
 		"id": 337,
-		"searchTerms": [],
+		"searchTerms": [
+			"Senbon-zakura"
+		],
 		"title": "千本桜"
 	},
 	{
@@ -4448,7 +4782,9 @@
 			"titleJP": "ファムファタール"
 		},
 		"id": 342,
-		"searchTerms": [],
+		"searchTerms": [
+			"Femme Fatale"
+		],
 		"title": "ファムファタール"
 	},
 	{
@@ -4461,7 +4797,9 @@
 			"titleJP": "アゲナゲン"
 		},
 		"id": 343,
-		"searchTerms": [],
+		"searchTerms": [
+			"Agenagen"
+		],
 		"title": "アゲナゲン"
 	},
 	{
@@ -4474,7 +4812,9 @@
 			"titleJP": "テンガク"
 		},
 		"id": 344,
-		"searchTerms": [],
+		"searchTerms": [
+			"Tengaku"
+		],
 		"title": "天樂"
 	},
 	{
@@ -4487,7 +4827,9 @@
 			"titleJP": "メルト"
 		},
 		"id": 345,
-		"searchTerms": [],
+		"searchTerms": [
+			"Melt"
+		],
 		"title": "メルト"
 	},
 	{
@@ -4500,7 +4842,9 @@
 			"titleJP": "ヨシワララメント"
 		},
 		"id": 346,
-		"searchTerms": [],
+		"searchTerms": [
+			"Yoshiwara Lament"
+		],
 		"title": "吉原ラメント"
 	},
 	{
@@ -4513,7 +4857,9 @@
 			"titleJP": "クリムゾンテイオウ"
 		},
 		"id": 347,
-		"searchTerms": [],
+		"searchTerms": [
+			"Crimson Teio"
+		],
 		"title": "クリムゾン帝王"
 	},
 	{
@@ -4526,7 +4872,9 @@
 			"titleJP": "エフェメラ"
 		},
 		"id": 348,
-		"searchTerms": [],
+		"searchTerms": [
+			"[EPHEMERA]"
+		],
 		"title": "EPHMR"
 	},
 	{
@@ -4595,5 +4943,20 @@
 		"id": 353,
 		"searchTerms": [],
 		"title": "CENSORED!!"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Myosuke vs MASAKI",
+		"data": {
+			"artistJP": "ディージェーミョースケ バーサス マサキ",
+			"displayVersion": "reverse",
+			"genre": "オリジナル",
+			"titleJP": "カミ"
+		},
+		"id": 354,
+		"searchTerms": [
+			"Kami"
+		],
+		"title": "神"
 	}
 ]

--- a/scripts/rerunners/parse-wacca-dataset.js
+++ b/scripts/rerunners/parse-wacca-dataset.js
@@ -7,6 +7,8 @@ const logger = require("../logger");
 
 const program = new Command();
 
+logger.warn(`Rating-dataset.js is evaluated. Please make sure you've read the file before you run it.`);
+
 // https://github.com/shimmand/waccaSupportTools/blob/main/analyzePlayData/rating-dataset.js
 // Please look at the file before running, it is eval'd and can execute arbitrary code.
 program.requiredOption("-r, --rating-js <rating-dataset.js>");


### PR DESCRIPTION
This uses the actual js dataset that is used by waccaSupportTools, which is updated more regularly than the CSV. It is a bit more dangerous in that we have to execute javascript to get the data. 
The new dataset also has english translations/transliterations of japanese titles, which I've added to searchTerms.
This also adds new charts from the past couple of weeks.

Note that there are a few issues with the dataset I found, and I've opened upstream PRs to fix these.