### PR TITLE
clean up charts removed from konaste

### DIFF
--- a/collections/charts-sdvx.json
+++ b/collections/charts-sdvx.json
@@ -19,7 +19,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43,7 +42,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73,7 +71,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -97,7 +94,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -739,7 +735,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -763,7 +758,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -787,7 +781,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -2263,7 +2256,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -2287,7 +2279,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -2311,7 +2302,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3505,7 +3495,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3529,7 +3518,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3553,7 +3541,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3787,7 +3774,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3811,7 +3797,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3835,7 +3820,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3859,7 +3843,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3883,7 +3866,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3907,7 +3889,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3931,7 +3912,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3955,7 +3935,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -3979,7 +3958,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4072,7 +4050,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4096,7 +4073,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4120,7 +4096,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4312,7 +4287,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4336,7 +4310,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4366,7 +4339,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4390,7 +4362,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4414,7 +4385,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4438,7 +4408,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4462,7 +4431,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4486,7 +4454,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4510,7 +4477,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4540,7 +4506,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -4564,7 +4529,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5428,7 +5392,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5452,7 +5415,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5482,7 +5444,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5506,7 +5467,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5734,7 +5694,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5758,7 +5717,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5788,7 +5746,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -5812,7 +5769,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6118,7 +6074,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6142,7 +6097,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6166,7 +6120,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6190,7 +6143,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6214,7 +6166,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6238,7 +6189,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6262,7 +6212,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6286,7 +6235,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6310,7 +6258,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6334,7 +6281,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6358,7 +6304,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6382,7 +6327,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6412,7 +6356,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6436,7 +6379,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6794,7 +6736,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6818,7 +6759,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6842,7 +6782,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6866,7 +6805,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6890,7 +6828,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6914,7 +6851,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6938,7 +6874,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6962,7 +6897,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -6986,7 +6920,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -8598,7 +8531,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -8622,7 +8554,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -8646,7 +8577,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -8676,7 +8606,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -8700,7 +8629,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -8724,7 +8652,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -8748,7 +8675,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9076,7 +9002,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9100,7 +9025,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9124,7 +9048,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9217,7 +9140,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9241,7 +9163,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9265,7 +9186,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9289,7 +9209,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9313,7 +9232,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9337,7 +9255,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9361,7 +9278,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9385,7 +9301,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9409,7 +9324,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9955,7 +9869,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -9979,7 +9892,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -10009,7 +9921,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -10033,7 +9944,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11725,7 +11635,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11749,7 +11658,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11773,7 +11681,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11797,7 +11704,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11821,7 +11727,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11845,7 +11750,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11869,7 +11773,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11893,7 +11796,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11917,7 +11819,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11941,7 +11842,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11965,7 +11865,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -11989,7 +11888,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12013,7 +11911,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12037,7 +11934,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12061,7 +11957,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12085,7 +11980,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12109,7 +12003,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12133,7 +12026,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12157,7 +12049,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12181,7 +12072,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12205,7 +12095,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12229,7 +12118,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12259,7 +12147,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12289,7 +12176,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12313,7 +12199,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12409,7 +12294,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12433,7 +12317,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12457,7 +12340,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12481,7 +12363,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12505,7 +12386,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12529,7 +12409,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12656,7 +12535,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12679,7 +12557,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12702,7 +12579,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12725,7 +12601,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12748,7 +12623,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12771,7 +12645,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12800,7 +12673,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12823,7 +12695,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12846,7 +12717,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12869,7 +12739,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12892,7 +12761,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12915,7 +12783,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -12938,7 +12805,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13106,7 +12972,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13130,7 +12995,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13154,7 +13018,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13430,7 +13293,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13454,7 +13316,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13478,7 +13339,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13502,7 +13362,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13526,7 +13385,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13550,7 +13408,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13646,7 +13503,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13670,7 +13526,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13694,7 +13549,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13717,7 +13571,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13740,7 +13593,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13763,7 +13615,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13787,7 +13638,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13811,7 +13661,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -13835,7 +13684,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14031,7 +13879,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14054,7 +13901,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14077,7 +13923,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14100,7 +13945,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14123,7 +13967,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14146,7 +13989,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14169,7 +14011,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14192,7 +14033,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -14215,7 +14055,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16108,7 +15947,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16131,7 +15969,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16154,7 +15991,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16615,7 +16451,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16638,7 +16473,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16661,7 +16495,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16926,7 +16759,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16949,7 +16781,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -16972,7 +16803,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -17174,7 +17004,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -17197,7 +17026,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -17220,7 +17048,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -17347,7 +17174,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -17370,7 +17196,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -17393,7 +17218,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18038,7 +17862,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18067,7 +17890,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18090,7 +17912,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18113,7 +17934,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18136,7 +17956,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18159,7 +17978,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18907,7 +18725,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18930,7 +18747,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -18953,7 +18769,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20757,7 +20572,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20786,7 +20600,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20809,7 +20622,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20838,7 +20650,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20861,7 +20672,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20884,7 +20694,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20907,7 +20716,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20930,7 +20738,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20953,7 +20760,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -20982,7 +20788,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21005,7 +20810,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21028,7 +20832,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21051,7 +20854,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21074,7 +20876,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21097,7 +20898,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21120,7 +20920,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21143,7 +20942,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21166,7 +20964,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21189,7 +20986,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21218,7 +21014,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21241,7 +21036,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21264,7 +21058,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21287,7 +21080,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21310,7 +21102,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21333,7 +21124,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21356,7 +21146,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21379,7 +21168,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21402,7 +21190,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21425,7 +21212,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21448,7 +21234,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21471,7 +21256,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21500,7 +21284,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21523,7 +21306,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21759,7 +21541,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21788,7 +21569,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -21811,7 +21591,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22047,7 +21826,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22070,7 +21848,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22093,7 +21870,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22116,7 +21892,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22139,7 +21914,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22162,7 +21936,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22185,7 +21958,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22214,7 +21986,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22237,7 +22008,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22260,7 +22030,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22283,7 +22052,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22306,7 +22074,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22433,7 +22200,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22456,7 +22222,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22479,7 +22244,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22502,7 +22266,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22525,7 +22288,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22548,7 +22310,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22744,7 +22505,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22767,7 +22527,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22790,7 +22549,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22882,7 +22640,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22911,7 +22668,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -22934,7 +22690,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23130,7 +22885,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23153,7 +22907,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23176,7 +22929,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23199,7 +22951,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23228,7 +22979,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23251,7 +23001,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23274,7 +23023,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23297,7 +23045,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23320,7 +23067,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23343,7 +23089,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23366,7 +23111,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23389,7 +23133,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23412,7 +23155,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23435,7 +23177,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23458,7 +23199,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23550,7 +23290,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23573,7 +23312,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23596,7 +23334,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23619,7 +23356,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23642,7 +23378,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23665,7 +23400,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23688,7 +23422,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23711,7 +23444,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23734,7 +23466,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23826,7 +23557,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23855,7 +23585,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23878,7 +23607,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23967,7 +23695,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -23990,7 +23717,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24013,7 +23739,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24102,7 +23827,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24125,7 +23849,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24148,7 +23871,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24243,7 +23965,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24272,7 +23993,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24301,7 +24021,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24324,7 +24043,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24347,7 +24065,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24370,7 +24087,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24393,7 +24109,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24416,7 +24131,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24445,7 +24159,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24468,7 +24181,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24635,7 +24347,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24658,7 +24369,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -24681,7 +24391,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -25372,7 +25081,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -25395,7 +25103,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -25418,7 +25125,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26513,7 +26219,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26536,7 +26241,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26559,7 +26263,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26582,7 +26285,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26605,7 +26307,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26628,7 +26329,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26651,7 +26351,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26680,7 +26379,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -26703,7 +26401,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -27950,7 +27647,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -27973,7 +27669,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -28002,7 +27697,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -28025,7 +27719,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -28250,7 +27943,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -28279,7 +27971,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -28308,7 +27999,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -28331,7 +28021,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29118,7 +28807,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29141,7 +28829,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29164,7 +28851,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29262,7 +28948,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29285,7 +28970,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29308,7 +28992,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29475,7 +29158,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29498,7 +29180,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29521,7 +29202,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29688,7 +29368,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29711,7 +29390,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -29734,7 +29412,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30011,7 +29688,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30034,7 +29710,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30057,7 +29732,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30080,7 +29754,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30109,7 +29782,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30132,7 +29804,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30716,7 +30387,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30739,7 +30409,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30762,7 +30431,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30929,7 +30597,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30958,7 +30625,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -30981,7 +30647,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31004,7 +30669,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31033,7 +30697,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31056,7 +30719,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31079,7 +30741,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31102,7 +30763,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31125,7 +30785,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31148,7 +30807,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31171,7 +30829,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31194,7 +30851,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31217,7 +30873,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31246,7 +30901,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31269,7 +30923,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31505,7 +31158,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31528,7 +31180,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31551,7 +31202,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31649,7 +31299,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31678,7 +31327,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31701,7 +31349,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31724,7 +31371,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31753,7 +31399,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31776,7 +31421,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31799,7 +31443,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31822,7 +31465,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31845,7 +31487,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31868,7 +31509,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31891,7 +31531,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31914,7 +31553,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31937,7 +31575,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31960,7 +31597,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -31983,7 +31619,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32380,7 +32015,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32409,7 +32043,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32432,7 +32065,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32455,7 +32087,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32484,7 +32115,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32507,7 +32137,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32530,7 +32159,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32553,7 +32181,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32576,7 +32203,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32789,7 +32415,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32812,7 +32437,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32835,7 +32459,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32858,7 +32481,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32881,7 +32503,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -32904,7 +32525,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33353,7 +32973,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33376,7 +32995,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33405,7 +33023,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33428,7 +33045,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33451,7 +33067,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33480,7 +33095,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33509,7 +33123,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33532,7 +33145,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33655,7 +33267,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33678,7 +33289,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33701,7 +33311,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33724,7 +33333,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33747,7 +33355,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33770,7 +33377,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33793,7 +33399,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33816,7 +33421,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33839,7 +33443,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33862,7 +33465,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33885,7 +33487,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33908,7 +33509,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33931,7 +33531,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33960,7 +33559,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -33983,7 +33581,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34081,7 +33678,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34104,7 +33700,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34127,7 +33722,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34219,7 +33813,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34242,7 +33835,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34265,7 +33857,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34357,7 +33948,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34386,7 +33976,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34409,7 +33998,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34432,7 +34020,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34455,7 +34042,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -34478,7 +34064,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35011,7 +34596,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35039,7 +34623,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35061,7 +34644,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35084,7 +34666,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35113,7 +34694,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35136,7 +34716,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35159,7 +34738,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35182,7 +34760,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35205,7 +34782,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35228,7 +34804,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35257,7 +34832,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35280,7 +34854,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35943,7 +35516,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35966,7 +35538,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -35989,7 +35560,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36012,7 +35582,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36041,7 +35610,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36064,7 +35632,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36307,7 +35874,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36330,7 +35896,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36353,7 +35918,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36375,7 +35939,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36397,7 +35960,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36419,7 +35981,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36504,7 +36065,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36526,7 +36086,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36548,7 +36107,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36571,7 +36129,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36594,7 +36151,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36617,7 +36173,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36703,7 +36258,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36726,7 +36280,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36749,7 +36302,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36771,7 +36323,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36793,7 +36344,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36815,7 +36365,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36837,7 +36386,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36859,7 +36407,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -36881,7 +36428,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -38675,7 +38221,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -38697,7 +38242,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -38719,7 +38263,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -39256,7 +38799,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -39278,7 +38820,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -39300,7 +38841,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40012,7 +39552,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40034,7 +39573,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40056,7 +39594,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40366,7 +39903,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40394,7 +39930,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40416,7 +39951,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40438,7 +39972,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40466,7 +39999,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40488,7 +40020,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40928,7 +40459,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40950,7 +40480,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -40972,7 +40501,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -41066,7 +40594,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -41094,7 +40621,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -41116,7 +40642,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42409,7 +41934,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42431,7 +41955,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42453,7 +41976,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42538,7 +42060,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42560,7 +42081,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42582,7 +42102,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42604,7 +42123,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42626,7 +42144,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42648,7 +42165,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42670,7 +42186,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42692,7 +42207,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42714,7 +42228,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42736,7 +42249,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42758,7 +42270,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42780,7 +42291,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42802,7 +42312,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42824,7 +42333,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42846,7 +42354,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42868,7 +42375,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42896,7 +42402,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -42918,7 +42423,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43003,7 +42507,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43031,7 +42534,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43053,7 +42555,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43075,7 +42576,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43097,7 +42597,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43119,7 +42618,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43141,7 +42639,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43169,7 +42666,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43191,7 +42687,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43795,7 +43290,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43823,7 +43317,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -43845,7 +43338,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -44353,7 +43845,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -44381,7 +43872,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -44403,7 +43893,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -45895,7 +45384,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -45917,7 +45405,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -45939,7 +45426,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46487,7 +45973,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46515,7 +46000,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46537,7 +46021,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46625,7 +46108,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46653,7 +46135,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46675,7 +46156,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46769,7 +46249,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46797,7 +46276,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -46819,7 +46297,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49201,7 +48678,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49229,7 +48705,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49251,7 +48726,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49402,7 +48876,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49424,7 +48897,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49446,7 +48918,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49468,7 +48939,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49496,7 +48966,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49518,7 +48987,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49540,7 +49008,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49568,7 +49035,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49590,7 +49056,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49678,7 +49143,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49706,7 +49170,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49728,7 +49191,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49750,7 +49212,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49772,7 +49233,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49794,7 +49254,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49816,7 +49275,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49838,7 +49296,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49860,7 +49317,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49882,7 +49338,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49910,7 +49365,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49932,7 +49386,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49954,7 +49407,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -49982,7 +49434,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50004,7 +49455,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50026,7 +49476,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50054,7 +49503,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50076,7 +49524,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50098,7 +49545,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50126,7 +49572,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50148,7 +49593,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50242,7 +49686,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50264,7 +49707,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50286,7 +49728,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50668,7 +50109,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50696,7 +50136,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50724,7 +50163,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -50746,7 +50184,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51588,7 +51025,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51616,7 +51052,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51644,7 +51079,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51666,7 +51100,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51688,7 +51121,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51716,7 +51148,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51738,7 +51169,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51760,7 +51190,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51788,7 +51217,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51810,7 +51238,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51904,7 +51331,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51932,7 +51358,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -51954,7 +51379,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -52180,7 +51604,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -52208,7 +51631,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -52230,7 +51652,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53464,7 +52885,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53492,7 +52912,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53514,7 +52933,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53608,7 +53026,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53630,7 +53047,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53652,7 +53068,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53674,7 +53089,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53702,7 +53116,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53724,7 +53137,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53746,7 +53158,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53768,7 +53179,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53790,7 +53200,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53812,7 +53221,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53834,7 +53242,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53856,7 +53263,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53950,7 +53356,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -53978,7 +53383,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54000,7 +53404,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54094,7 +53497,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54122,7 +53524,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54144,7 +53545,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54166,7 +53566,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54194,7 +53593,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54216,7 +53614,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54382,7 +53779,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54410,7 +53806,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54432,7 +53827,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54454,7 +53848,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54482,7 +53875,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54504,7 +53896,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54592,7 +53983,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54620,7 +54010,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54642,7 +54031,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54664,7 +54052,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54686,7 +54073,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54708,7 +54094,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54802,7 +54187,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54824,7 +54208,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54846,7 +54229,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54868,7 +54250,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54890,7 +54271,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54912,7 +54292,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54934,7 +54313,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54962,7 +54340,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -54984,7 +54361,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55006,7 +54382,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55034,7 +54409,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55056,7 +54430,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55078,7 +54451,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55106,7 +54478,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55128,7 +54499,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55222,7 +54592,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55250,7 +54619,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55272,7 +54640,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55294,7 +54661,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55316,7 +54682,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55338,7 +54703,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55360,7 +54724,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55388,7 +54751,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55410,7 +54772,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55432,7 +54793,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55460,7 +54820,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55482,7 +54841,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55504,7 +54862,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55526,7 +54883,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55548,7 +54904,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55846,7 +55201,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55868,7 +55222,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55890,7 +55243,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -55978,7 +55330,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -56000,7 +55351,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -56022,7 +55372,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -56398,7 +55747,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -56426,7 +55774,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -56448,7 +55795,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -57186,7 +56532,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -57214,7 +56559,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -57236,7 +56580,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -58714,7 +58057,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -58742,7 +58084,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -58764,7 +58105,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -60346,7 +59686,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -60374,7 +59713,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -60396,7 +59734,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -61634,7 +60971,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -61662,7 +60998,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -61684,7 +61019,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -61706,7 +61040,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -61734,7 +61067,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -61756,7 +61088,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -62012,7 +61343,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -62040,7 +61370,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -62062,7 +61391,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -64493,7 +63821,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -64521,7 +63848,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -64543,7 +63869,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -65393,7 +64718,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -65415,7 +64739,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -65437,7 +64760,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -66837,7 +66159,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -66865,7 +66186,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -66887,7 +66207,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67009,7 +66328,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67037,7 +66355,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67059,7 +66376,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67081,7 +66397,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67103,7 +66418,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67125,7 +66439,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67291,7 +66604,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67319,7 +66631,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -67341,7 +66652,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -71250,7 +70560,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -71278,7 +70587,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -71300,7 +70608,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -71322,7 +70629,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -71350,7 +70656,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -71372,7 +70677,6 @@
 			"gw",
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73003,7 +72307,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73024,7 +72327,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73051,7 +72353,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73072,7 +72373,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73177,7 +72477,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73198,7 +72497,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73225,7 +72523,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73246,7 +72543,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73813,7 +73109,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73834,7 +73129,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73861,7 +73155,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -73882,7 +73175,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74695,7 +73987,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74716,7 +74007,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74743,7 +74033,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74764,7 +74053,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74785,7 +74073,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74806,7 +74093,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74833,7 +74119,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74854,7 +74139,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74965,7 +74249,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -74986,7 +74269,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -75013,7 +74295,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -75034,7 +74315,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -75415,7 +74695,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -75436,7 +74715,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -75463,7 +74741,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -75484,7 +74761,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76039,7 +75315,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76060,7 +75335,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76087,7 +75361,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76108,7 +75381,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76579,7 +75851,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76600,7 +75871,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76627,7 +75897,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76648,7 +75917,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76843,7 +76111,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76864,7 +76131,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76891,7 +76157,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76912,7 +76177,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76933,7 +76197,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76954,7 +76217,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -76981,7 +76243,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -77002,7 +76263,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -77473,7 +76733,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -77494,7 +76753,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -77521,7 +76779,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -77542,7 +76799,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -80077,7 +79333,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -80098,7 +79353,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -80125,7 +79379,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -80146,7 +79399,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85487,7 +84739,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85508,7 +84759,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85535,7 +84785,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85556,7 +84805,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85751,7 +84999,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85772,7 +85019,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85799,7 +85045,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -85820,7 +85065,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -89147,7 +88391,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -89168,7 +88411,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -89195,7 +88437,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -89216,7 +88457,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90683,7 +89923,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90704,7 +89943,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90731,7 +89969,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90752,7 +89989,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90863,7 +90099,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90884,7 +90119,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90911,7 +90145,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -90932,7 +90165,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -91043,7 +90275,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -91064,7 +90295,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -91091,7 +90321,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -91112,7 +90341,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93383,7 +92611,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93404,7 +92631,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93431,7 +92657,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93452,7 +92677,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93845,7 +93069,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93866,7 +93089,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93893,7 +93115,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -93914,7 +93135,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94025,7 +93245,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94046,7 +93265,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94073,7 +93291,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94094,7 +93311,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94751,7 +93967,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94772,7 +93987,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94799,7 +94013,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -94820,7 +94033,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96142,7 +95354,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96163,7 +95374,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96190,7 +95400,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96211,7 +95420,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96682,7 +95890,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96703,7 +95910,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96730,7 +95936,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -96751,7 +95956,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -97510,7 +96714,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -97531,7 +96734,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -97558,7 +96760,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -97579,7 +96780,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -101086,7 +100286,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -101107,7 +100306,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -101134,7 +100332,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -101155,7 +100352,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -103882,7 +103078,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -103903,7 +103098,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -103930,7 +103124,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -103951,7 +103144,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104428,7 +103620,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104449,7 +103640,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104476,7 +103666,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104497,7 +103686,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104518,7 +103706,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104539,7 +103726,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104566,7 +103752,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},
@@ -104587,7 +103772,6 @@
 		"versions": [
 			"heaven",
 			"vivid",
-			"konaste",
 			"exceed"
 		]
 	},


### PR DESCRIPTION
This were available in a previous version of sdvx konaste (e.g. gravity wars) but aren't available in the current version. This removes the version tag so that the konaste folders are correct.