### PR TITLE
Added Jubeat Clan charts to charts and songs.

### DIFF
--- a/collections/charts-jubeat.json
+++ b/collections/charts-jubeat.json
@@ -14,6 +14,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32,6 +33,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50,6 +52,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68,6 +71,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -86,6 +90,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -104,6 +109,7 @@
 		"songID": 1,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -122,6 +128,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -140,6 +147,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -158,6 +166,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -176,6 +185,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -194,6 +204,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -212,6 +223,7 @@
 		"songID": 2,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -230,6 +242,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -248,6 +261,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -266,6 +280,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -284,6 +299,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -302,6 +318,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -320,6 +337,7 @@
 		"songID": 3,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -338,6 +356,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -356,6 +375,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -374,6 +394,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -392,6 +413,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -410,6 +432,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -428,6 +451,7 @@
 		"songID": 4,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -446,6 +470,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -464,6 +489,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -482,6 +508,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -500,6 +527,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -518,6 +546,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -536,6 +565,7 @@
 		"songID": 5,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -554,6 +584,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -572,6 +603,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -590,6 +622,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -608,6 +641,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -626,6 +660,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -644,6 +679,7 @@
 		"songID": 6,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -662,6 +698,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -680,6 +717,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -698,6 +736,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -716,6 +755,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -734,6 +774,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -752,6 +793,7 @@
 		"songID": 7,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -770,6 +812,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -788,6 +831,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -806,6 +850,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -824,6 +869,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -842,6 +888,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -860,6 +907,7 @@
 		"songID": 8,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -878,6 +926,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -896,6 +945,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -914,6 +964,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -932,6 +983,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -950,6 +1002,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -968,6 +1021,7 @@
 		"songID": 9,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -986,6 +1040,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1004,6 +1059,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1022,6 +1078,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1040,6 +1097,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1058,6 +1116,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1076,6 +1135,7 @@
 		"songID": 10,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1094,6 +1154,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1112,6 +1173,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1130,6 +1192,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1148,6 +1211,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1166,6 +1230,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1184,6 +1249,7 @@
 		"songID": 11,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1202,6 +1268,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1220,6 +1287,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1238,6 +1306,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1256,6 +1325,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1274,6 +1344,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1292,6 +1363,7 @@
 		"songID": 12,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1310,6 +1382,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1328,6 +1401,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1346,6 +1420,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1364,6 +1439,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1382,6 +1458,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1400,6 +1477,7 @@
 		"songID": 13,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1418,6 +1496,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1436,6 +1515,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1454,6 +1534,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1472,6 +1553,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1490,6 +1572,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1508,6 +1591,7 @@
 		"songID": 14,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1526,6 +1610,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1544,6 +1629,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1562,6 +1648,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1580,6 +1667,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1598,6 +1686,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1616,6 +1705,7 @@
 		"songID": 15,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1634,6 +1724,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1652,6 +1743,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1670,6 +1762,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1688,6 +1781,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1706,6 +1800,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1724,6 +1819,7 @@
 		"songID": 16,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1742,6 +1838,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1760,6 +1857,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1778,6 +1876,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1796,6 +1895,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1814,6 +1914,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1832,6 +1933,7 @@
 		"songID": 17,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1850,6 +1952,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1868,6 +1971,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1886,6 +1990,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1904,6 +2009,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1922,6 +2028,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1940,6 +2047,7 @@
 		"songID": 18,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1958,6 +2066,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1976,6 +2085,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -1994,6 +2104,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2012,6 +2123,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2030,6 +2142,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2048,6 +2161,7 @@
 		"songID": 19,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2066,6 +2180,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2084,6 +2199,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2102,6 +2218,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2120,6 +2237,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2138,6 +2256,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2156,6 +2275,7 @@
 		"songID": 20,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2174,6 +2294,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2192,6 +2313,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2210,6 +2332,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2228,6 +2351,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2246,6 +2370,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2264,6 +2389,7 @@
 		"songID": 21,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2282,6 +2408,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2300,6 +2427,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2318,6 +2446,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2336,6 +2465,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2354,6 +2484,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2372,6 +2503,7 @@
 		"songID": 22,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2390,6 +2522,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2408,6 +2541,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2426,6 +2560,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2444,6 +2579,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2462,6 +2598,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2480,6 +2617,7 @@
 		"songID": 23,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2498,6 +2636,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2516,6 +2655,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2534,6 +2674,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2552,6 +2693,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2570,6 +2712,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2588,6 +2731,7 @@
 		"songID": 24,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2606,6 +2750,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2624,6 +2769,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2642,6 +2788,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2660,6 +2807,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2678,6 +2826,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2696,6 +2845,7 @@
 		"songID": 25,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2714,6 +2864,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2732,6 +2883,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2750,6 +2902,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2768,6 +2921,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2786,6 +2940,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2804,6 +2959,7 @@
 		"songID": 26,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2822,6 +2978,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2840,6 +2997,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2858,6 +3016,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2876,6 +3035,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2894,6 +3054,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2912,6 +3073,7 @@
 		"songID": 27,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2930,6 +3092,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2948,6 +3111,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2966,6 +3130,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -2984,6 +3149,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3002,6 +3168,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3020,6 +3187,7 @@
 		"songID": 28,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3038,6 +3206,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3056,6 +3225,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3074,6 +3244,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3092,6 +3263,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3110,6 +3282,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3128,6 +3301,7 @@
 		"songID": 29,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3146,6 +3320,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3164,6 +3339,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3182,6 +3358,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3200,6 +3377,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3218,6 +3396,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3236,6 +3415,7 @@
 		"songID": 30,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3254,6 +3434,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3272,6 +3453,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3290,6 +3472,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3308,6 +3491,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3326,6 +3510,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3344,6 +3529,7 @@
 		"songID": 31,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3362,6 +3548,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3380,6 +3567,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3398,6 +3586,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3416,6 +3605,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3434,6 +3624,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3452,6 +3643,7 @@
 		"songID": 32,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3470,6 +3662,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3488,6 +3681,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3506,6 +3700,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3524,6 +3719,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3542,6 +3738,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3560,6 +3757,7 @@
 		"songID": 33,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3578,6 +3776,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3596,6 +3795,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3614,6 +3814,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3632,6 +3833,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3650,6 +3852,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3668,6 +3871,7 @@
 		"songID": 34,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3686,6 +3890,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3704,6 +3909,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3722,6 +3928,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3740,6 +3947,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3758,6 +3966,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3776,6 +3985,7 @@
 		"songID": 35,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3794,6 +4004,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3812,6 +4023,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3830,6 +4042,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3848,6 +4061,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3866,6 +4080,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3884,6 +4099,7 @@
 		"songID": 36,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3902,6 +4118,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3920,6 +4137,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3938,6 +4156,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3956,6 +4175,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3974,6 +4194,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -3992,6 +4213,7 @@
 		"songID": 37,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4010,6 +4232,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4028,6 +4251,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4046,6 +4270,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4064,6 +4289,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4082,6 +4308,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4100,6 +4327,7 @@
 		"songID": 38,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4118,6 +4346,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4136,6 +4365,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4154,6 +4384,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4172,6 +4403,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4190,6 +4422,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4208,6 +4441,7 @@
 		"songID": 39,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4226,6 +4460,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4244,6 +4479,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4262,6 +4498,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4280,6 +4517,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4298,6 +4536,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4316,6 +4555,7 @@
 		"songID": 40,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4334,6 +4574,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4352,6 +4593,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4370,6 +4612,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4388,6 +4631,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4406,6 +4650,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4424,6 +4669,7 @@
 		"songID": 41,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4442,6 +4688,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4460,6 +4707,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4478,6 +4726,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4496,6 +4745,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4514,6 +4764,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4532,6 +4783,7 @@
 		"songID": 42,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4550,6 +4802,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4568,6 +4821,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4586,6 +4840,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4604,6 +4859,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4622,6 +4878,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4640,6 +4897,7 @@
 		"songID": 43,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4658,6 +4916,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4676,6 +4935,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4694,6 +4954,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4712,6 +4973,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4730,6 +4992,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4748,6 +5011,7 @@
 		"songID": 44,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4766,6 +5030,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4784,6 +5049,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4802,6 +5068,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4820,6 +5087,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4838,6 +5106,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4856,6 +5125,7 @@
 		"songID": 45,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4874,6 +5144,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4892,6 +5163,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4910,6 +5182,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4928,6 +5201,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4946,6 +5220,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4964,6 +5239,7 @@
 		"songID": 46,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -4982,6 +5258,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5000,6 +5277,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5018,6 +5296,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5036,6 +5315,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5054,6 +5334,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5072,6 +5353,7 @@
 		"songID": 47,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5090,6 +5372,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5108,6 +5391,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5126,6 +5410,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5144,6 +5429,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5162,6 +5448,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5180,6 +5467,7 @@
 		"songID": 48,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5198,6 +5486,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5216,6 +5505,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5234,6 +5524,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5252,6 +5543,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5270,6 +5562,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5288,6 +5581,7 @@
 		"songID": 49,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5306,6 +5600,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5324,6 +5619,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5342,6 +5638,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5360,6 +5657,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5378,6 +5676,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5396,6 +5695,7 @@
 		"songID": 50,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5414,6 +5714,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5432,6 +5733,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5450,6 +5752,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5468,6 +5771,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5486,6 +5790,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5504,6 +5809,7 @@
 		"songID": 51,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5522,6 +5828,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5540,6 +5847,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5558,6 +5866,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5576,6 +5885,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5594,6 +5904,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5612,6 +5923,7 @@
 		"songID": 52,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5630,6 +5942,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5648,6 +5961,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5666,6 +5980,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5684,6 +5999,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5702,6 +6018,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5720,6 +6037,7 @@
 		"songID": 53,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5738,6 +6056,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5756,6 +6075,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5774,6 +6094,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5792,6 +6113,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5810,6 +6132,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5828,6 +6151,7 @@
 		"songID": 54,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5846,6 +6170,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5864,6 +6189,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5882,6 +6208,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5900,6 +6227,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5918,6 +6246,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5936,6 +6265,7 @@
 		"songID": 55,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5954,6 +6284,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5972,6 +6303,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -5990,6 +6322,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6008,6 +6341,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6026,6 +6360,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6044,6 +6379,7 @@
 		"songID": 56,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6062,6 +6398,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6080,6 +6417,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6098,6 +6436,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6116,6 +6455,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6134,6 +6474,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6152,6 +6493,7 @@
 		"songID": 57,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6170,6 +6512,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6188,6 +6531,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6206,6 +6550,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6224,6 +6569,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6242,6 +6588,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6260,6 +6607,7 @@
 		"songID": 58,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6278,6 +6626,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6296,6 +6645,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6314,6 +6664,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6332,6 +6683,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6350,6 +6702,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6368,6 +6721,7 @@
 		"songID": 59,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6386,6 +6740,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6404,6 +6759,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6422,6 +6778,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6440,6 +6797,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6458,6 +6816,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6476,6 +6835,7 @@
 		"songID": 60,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6494,6 +6854,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6512,6 +6873,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6530,6 +6892,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6548,6 +6911,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6566,6 +6930,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6584,6 +6949,7 @@
 		"songID": 61,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6602,6 +6968,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6620,6 +6987,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6638,6 +7006,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6656,6 +7025,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6674,6 +7044,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6692,6 +7063,7 @@
 		"songID": 62,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6710,6 +7082,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6728,6 +7101,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6746,6 +7120,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6764,6 +7139,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6782,6 +7158,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6800,6 +7177,7 @@
 		"songID": 63,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6818,6 +7196,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6836,6 +7215,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6854,6 +7234,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6872,6 +7253,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6890,6 +7272,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6908,6 +7291,7 @@
 		"songID": 64,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6926,6 +7310,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6944,6 +7329,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6962,6 +7348,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6980,6 +7367,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -6998,6 +7386,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7016,6 +7405,7 @@
 		"songID": 65,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7034,6 +7424,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7052,6 +7443,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7070,6 +7462,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7088,6 +7481,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7106,6 +7500,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7124,6 +7519,7 @@
 		"songID": 66,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7142,6 +7538,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7160,6 +7557,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7178,6 +7576,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7196,6 +7595,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7214,6 +7614,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7232,6 +7633,7 @@
 		"songID": 67,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7250,6 +7652,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7268,6 +7671,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7286,6 +7690,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7304,6 +7709,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7322,6 +7728,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7340,6 +7747,7 @@
 		"songID": 68,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7358,6 +7766,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7376,6 +7785,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7394,6 +7804,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7412,6 +7823,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7430,6 +7842,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7448,6 +7861,7 @@
 		"songID": 69,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7466,6 +7880,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7484,6 +7899,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7502,6 +7918,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7520,6 +7937,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7538,6 +7956,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7556,6 +7975,7 @@
 		"songID": 70,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7574,6 +7994,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7592,6 +8013,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7610,6 +8032,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7628,6 +8051,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7646,6 +8070,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7664,6 +8089,7 @@
 		"songID": 71,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7682,6 +8108,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7700,6 +8127,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7718,6 +8146,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7736,6 +8165,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7754,6 +8184,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7772,6 +8203,7 @@
 		"songID": 72,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7790,6 +8222,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7808,6 +8241,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7826,6 +8260,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7844,6 +8279,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7862,6 +8298,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7880,6 +8317,7 @@
 		"songID": 73,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7898,6 +8336,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7916,6 +8355,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7934,6 +8374,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7952,6 +8393,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7970,6 +8412,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -7988,6 +8431,7 @@
 		"songID": 74,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8006,6 +8450,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8024,6 +8469,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8042,6 +8488,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8060,6 +8507,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8078,6 +8526,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8096,6 +8545,7 @@
 		"songID": 75,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8114,6 +8564,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8132,6 +8583,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8150,6 +8602,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8168,6 +8621,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8186,6 +8640,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8204,6 +8659,7 @@
 		"songID": 76,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8222,6 +8678,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8240,6 +8697,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8258,6 +8716,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8276,6 +8735,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8294,6 +8754,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8312,6 +8773,7 @@
 		"songID": 77,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8330,6 +8792,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8348,6 +8811,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8366,6 +8830,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8384,6 +8849,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8402,6 +8868,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8420,6 +8887,7 @@
 		"songID": 78,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8438,6 +8906,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8456,6 +8925,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8474,6 +8944,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8492,6 +8963,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8510,6 +8982,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8528,6 +9001,7 @@
 		"songID": 79,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8546,6 +9020,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8564,6 +9039,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8582,6 +9058,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8600,6 +9077,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8618,6 +9096,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8636,6 +9115,7 @@
 		"songID": 80,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8654,6 +9134,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8672,6 +9153,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8690,6 +9172,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8708,6 +9191,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8726,6 +9210,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8744,6 +9229,7 @@
 		"songID": 81,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8762,6 +9248,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8780,6 +9267,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8798,6 +9286,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8816,6 +9305,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8834,6 +9324,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8852,6 +9343,7 @@
 		"songID": 82,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8870,6 +9362,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8888,6 +9381,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8906,6 +9400,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8924,6 +9419,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8942,6 +9438,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8960,6 +9457,7 @@
 		"songID": 83,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8978,6 +9476,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -8996,6 +9495,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9014,6 +9514,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9032,6 +9533,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9050,6 +9552,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9068,6 +9571,7 @@
 		"songID": 84,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9086,6 +9590,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9104,6 +9609,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9122,6 +9628,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9140,6 +9647,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9158,6 +9666,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9176,6 +9685,7 @@
 		"songID": 85,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9194,6 +9704,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9212,6 +9723,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9230,6 +9742,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9248,6 +9761,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9266,6 +9780,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9284,6 +9799,7 @@
 		"songID": 86,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9302,6 +9818,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9320,6 +9837,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9338,6 +9856,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9356,6 +9875,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9374,6 +9894,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9392,6 +9913,7 @@
 		"songID": 87,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9410,6 +9932,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9428,6 +9951,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9446,6 +9970,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9464,6 +9989,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9482,6 +10008,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9500,6 +10027,7 @@
 		"songID": 88,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9518,6 +10046,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9536,6 +10065,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9554,6 +10084,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9572,6 +10103,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9590,6 +10122,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9608,6 +10141,7 @@
 		"songID": 89,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9626,6 +10160,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9644,6 +10179,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9662,6 +10198,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9680,6 +10217,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9698,6 +10236,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9716,6 +10255,7 @@
 		"songID": 90,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9734,6 +10274,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9752,6 +10293,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9770,6 +10312,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9788,6 +10331,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9806,6 +10350,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9824,6 +10369,7 @@
 		"songID": 91,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9842,6 +10388,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9860,6 +10407,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9878,6 +10426,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9896,6 +10445,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9914,6 +10464,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9932,6 +10483,7 @@
 		"songID": 92,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9950,6 +10502,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9968,6 +10521,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -9986,6 +10540,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10004,6 +10559,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10022,6 +10578,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10040,6 +10597,7 @@
 		"songID": 93,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10058,6 +10616,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10076,6 +10635,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10094,6 +10654,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10112,6 +10673,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10130,6 +10692,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10148,6 +10711,7 @@
 		"songID": 94,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10166,6 +10730,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10184,6 +10749,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10202,6 +10768,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10220,6 +10787,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10238,6 +10806,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10256,6 +10825,7 @@
 		"songID": 95,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10274,6 +10844,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10292,6 +10863,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10310,6 +10882,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10328,6 +10901,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10346,6 +10920,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10364,6 +10939,7 @@
 		"songID": 96,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10382,6 +10958,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10400,6 +10977,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10418,6 +10996,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10436,6 +11015,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10454,6 +11034,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10472,6 +11053,7 @@
 		"songID": 97,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10490,6 +11072,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10508,6 +11091,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10526,6 +11110,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10544,6 +11129,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10562,6 +11148,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10580,6 +11167,7 @@
 		"songID": 98,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10598,6 +11186,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10616,6 +11205,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10634,6 +11224,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10652,6 +11243,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10670,6 +11262,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10688,6 +11281,7 @@
 		"songID": 99,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10706,6 +11300,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10724,6 +11319,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10742,6 +11338,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10760,6 +11357,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10778,6 +11376,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10796,6 +11395,7 @@
 		"songID": 100,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10814,6 +11414,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10832,6 +11433,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10850,6 +11452,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10868,6 +11471,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10886,6 +11490,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10904,6 +11509,7 @@
 		"songID": 101,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10922,6 +11528,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10940,6 +11547,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10958,6 +11566,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10976,6 +11585,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -10994,6 +11604,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11012,6 +11623,7 @@
 		"songID": 102,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11030,6 +11642,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11048,6 +11661,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11066,6 +11680,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11084,6 +11699,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11102,6 +11718,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11120,6 +11737,7 @@
 		"songID": 103,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11138,6 +11756,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11156,6 +11775,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11174,6 +11794,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11192,6 +11813,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11210,6 +11832,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11228,6 +11851,7 @@
 		"songID": 104,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11246,6 +11870,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11264,6 +11889,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11282,6 +11908,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11300,6 +11927,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11318,6 +11946,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11336,6 +11965,7 @@
 		"songID": 105,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11354,6 +11984,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11372,6 +12003,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11390,6 +12022,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11408,6 +12041,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11426,6 +12060,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11444,6 +12079,7 @@
 		"songID": 106,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11462,6 +12098,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11480,6 +12117,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11498,6 +12136,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11516,6 +12155,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11534,6 +12174,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11552,6 +12193,7 @@
 		"songID": 107,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11570,6 +12212,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11588,6 +12231,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11606,6 +12250,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11624,6 +12269,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11642,6 +12288,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11660,6 +12307,7 @@
 		"songID": 108,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11678,6 +12326,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11696,6 +12345,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11714,6 +12364,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11732,6 +12383,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11750,6 +12402,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11768,6 +12421,7 @@
 		"songID": 109,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11786,6 +12440,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11804,6 +12459,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11822,6 +12478,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11840,6 +12497,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11858,6 +12516,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11876,6 +12535,7 @@
 		"songID": 110,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11894,6 +12554,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11912,6 +12573,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11930,6 +12592,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11948,6 +12611,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11966,6 +12630,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -11984,6 +12649,7 @@
 		"songID": 111,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12002,6 +12668,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12020,6 +12687,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12038,6 +12706,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12056,6 +12725,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12074,6 +12744,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12092,6 +12763,7 @@
 		"songID": 112,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12110,6 +12782,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12128,6 +12801,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12146,6 +12820,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12164,6 +12839,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12182,6 +12858,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12200,6 +12877,7 @@
 		"songID": 113,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12218,6 +12896,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12236,6 +12915,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12254,6 +12934,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12272,6 +12953,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12290,6 +12972,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12308,6 +12991,7 @@
 		"songID": 114,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12326,6 +13010,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12344,6 +13029,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12362,6 +13048,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12380,6 +13067,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12398,6 +13086,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12416,6 +13105,7 @@
 		"songID": 115,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12434,6 +13124,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12452,6 +13143,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12470,6 +13162,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12488,6 +13181,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12506,6 +13200,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12524,6 +13219,7 @@
 		"songID": 116,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12542,6 +13238,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12560,6 +13257,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12578,6 +13276,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12596,6 +13295,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12614,6 +13314,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12632,6 +13333,7 @@
 		"songID": 117,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12650,6 +13352,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12668,6 +13371,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12686,6 +13390,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12704,6 +13409,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12722,6 +13428,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12740,6 +13447,7 @@
 		"songID": 118,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12758,6 +13466,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12776,6 +13485,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12794,6 +13504,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12812,6 +13523,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12830,6 +13542,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12848,6 +13561,7 @@
 		"songID": 119,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12866,6 +13580,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12884,6 +13599,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12902,6 +13618,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12920,6 +13637,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12938,6 +13656,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12956,6 +13675,7 @@
 		"songID": 120,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12974,6 +13694,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -12992,6 +13713,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13010,6 +13732,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13028,6 +13751,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13046,6 +13770,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13064,6 +13789,7 @@
 		"songID": 121,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13082,6 +13808,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13100,6 +13827,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13118,6 +13846,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13136,6 +13865,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13154,6 +13884,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13172,6 +13903,7 @@
 		"songID": 122,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13190,6 +13922,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13208,6 +13941,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13226,6 +13960,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13244,6 +13979,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13262,6 +13998,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13280,6 +14017,7 @@
 		"songID": 123,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13298,6 +14036,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13316,6 +14055,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13334,6 +14074,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13352,6 +14093,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13370,6 +14112,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13388,6 +14131,7 @@
 		"songID": 124,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13406,6 +14150,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13424,6 +14169,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13442,6 +14188,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13460,6 +14207,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13478,6 +14226,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13496,6 +14245,7 @@
 		"songID": 125,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13514,6 +14264,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13532,6 +14283,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13550,6 +14302,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13568,6 +14321,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13586,6 +14340,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13604,6 +14359,7 @@
 		"songID": 126,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13622,6 +14378,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13640,6 +14397,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13658,6 +14416,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13676,6 +14435,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13694,6 +14454,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13712,6 +14473,7 @@
 		"songID": 127,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13730,6 +14492,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13748,6 +14511,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13766,6 +14530,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13784,6 +14549,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13802,6 +14568,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13820,6 +14587,7 @@
 		"songID": 128,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13838,6 +14606,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13856,6 +14625,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13874,6 +14644,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13892,6 +14663,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13910,6 +14682,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13928,6 +14701,7 @@
 		"songID": 129,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13946,6 +14720,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13964,6 +14739,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -13982,6 +14758,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14000,6 +14777,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14018,6 +14796,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14036,6 +14815,7 @@
 		"songID": 130,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14054,6 +14834,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14072,6 +14853,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14090,6 +14872,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14108,6 +14891,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14126,6 +14910,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14144,6 +14929,7 @@
 		"songID": 131,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14162,6 +14948,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14180,6 +14967,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14198,6 +14986,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14216,6 +15005,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14234,6 +15024,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14252,6 +15043,7 @@
 		"songID": 132,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14270,6 +15062,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14288,6 +15081,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14306,6 +15100,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14324,6 +15119,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14342,6 +15138,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14360,6 +15157,7 @@
 		"songID": 133,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14378,6 +15176,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14396,6 +15195,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14414,6 +15214,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14432,6 +15233,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14450,6 +15252,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14468,6 +15271,7 @@
 		"songID": 134,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14486,6 +15290,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14504,6 +15309,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14522,6 +15328,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14540,6 +15347,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14558,6 +15366,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14576,6 +15385,7 @@
 		"songID": 135,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14594,6 +15404,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14612,6 +15423,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14630,6 +15442,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14648,6 +15461,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14666,6 +15480,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14684,6 +15499,7 @@
 		"songID": 136,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14702,6 +15518,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14720,6 +15537,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14738,6 +15556,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14756,6 +15575,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14774,6 +15594,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14792,6 +15613,7 @@
 		"songID": 137,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14810,6 +15632,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14828,6 +15651,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14846,6 +15670,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14864,6 +15689,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14882,6 +15708,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14900,6 +15727,7 @@
 		"songID": 138,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14918,6 +15746,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14936,6 +15765,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14954,6 +15784,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14972,6 +15803,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -14990,6 +15822,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15008,6 +15841,7 @@
 		"songID": 139,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15026,6 +15860,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15044,6 +15879,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15062,6 +15898,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15080,6 +15917,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15098,6 +15936,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15116,6 +15955,7 @@
 		"songID": 140,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15134,6 +15974,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15152,6 +15993,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15170,6 +16012,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15188,6 +16031,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15206,6 +16050,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15224,6 +16069,7 @@
 		"songID": 141,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15242,6 +16088,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15260,6 +16107,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15278,6 +16126,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15296,6 +16145,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15314,6 +16164,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15332,6 +16183,7 @@
 		"songID": 142,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15350,6 +16202,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15368,6 +16221,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15386,6 +16240,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15404,6 +16259,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15422,6 +16278,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15440,6 +16297,7 @@
 		"songID": 143,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15458,6 +16316,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15476,6 +16335,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15494,6 +16354,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15512,6 +16373,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15530,6 +16392,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15548,6 +16411,7 @@
 		"songID": 144,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15566,6 +16430,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15584,6 +16449,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15602,6 +16468,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15620,6 +16487,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15638,6 +16506,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15656,6 +16525,7 @@
 		"songID": 145,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15674,6 +16544,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15692,6 +16563,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15710,6 +16582,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15728,6 +16601,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15746,6 +16620,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15764,6 +16639,7 @@
 		"songID": 146,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15782,6 +16658,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15800,6 +16677,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15818,6 +16696,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15836,6 +16715,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15854,6 +16734,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15872,6 +16753,7 @@
 		"songID": 147,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15890,6 +16772,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15908,6 +16791,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15926,6 +16810,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15944,6 +16829,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15962,6 +16848,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15980,6 +16867,7 @@
 		"songID": 148,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -15998,6 +16886,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16016,6 +16905,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16034,6 +16924,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16052,6 +16943,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16070,6 +16962,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16088,6 +16981,7 @@
 		"songID": 149,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16106,6 +17000,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16124,6 +17019,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16142,6 +17038,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16160,6 +17057,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16178,6 +17076,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16196,6 +17095,7 @@
 		"songID": 150,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16214,6 +17114,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16232,6 +17133,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16250,6 +17152,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16268,6 +17171,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16286,6 +17190,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16304,6 +17209,7 @@
 		"songID": 151,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16322,6 +17228,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16340,6 +17247,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16358,6 +17266,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16376,6 +17285,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16394,6 +17304,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16412,6 +17323,7 @@
 		"songID": 152,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16430,6 +17342,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16448,6 +17361,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16466,6 +17380,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16484,6 +17399,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16502,6 +17418,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16520,6 +17437,7 @@
 		"songID": 153,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16538,6 +17456,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16556,6 +17475,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16574,6 +17494,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16592,6 +17513,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16610,6 +17532,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16628,6 +17551,7 @@
 		"songID": 154,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16646,6 +17570,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16664,6 +17589,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16682,6 +17608,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16700,6 +17627,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16718,6 +17646,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16736,6 +17665,7 @@
 		"songID": 155,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16754,6 +17684,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16772,6 +17703,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16790,6 +17722,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16808,6 +17741,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16826,6 +17760,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16844,6 +17779,7 @@
 		"songID": 156,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16862,6 +17798,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16880,6 +17817,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16898,6 +17836,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16916,6 +17855,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16934,6 +17874,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16952,6 +17893,7 @@
 		"songID": 157,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16970,6 +17912,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -16988,6 +17931,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17006,6 +17950,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17024,6 +17969,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17042,6 +17988,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17060,6 +18007,7 @@
 		"songID": 158,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17078,6 +18026,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17096,6 +18045,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17114,6 +18064,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17132,6 +18083,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17150,6 +18102,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17168,6 +18121,7 @@
 		"songID": 159,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17186,6 +18140,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17204,6 +18159,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17222,6 +18178,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17240,6 +18197,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17258,6 +18216,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17276,6 +18235,7 @@
 		"songID": 160,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17294,6 +18254,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17312,6 +18273,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17330,6 +18292,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17348,6 +18311,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17366,6 +18330,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17384,6 +18349,7 @@
 		"songID": 161,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17402,6 +18368,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17420,6 +18387,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17438,6 +18406,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17456,6 +18425,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17474,6 +18444,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17492,6 +18463,7 @@
 		"songID": 162,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17510,6 +18482,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17528,6 +18501,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17546,6 +18520,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17564,6 +18539,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17582,6 +18558,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17600,6 +18577,7 @@
 		"songID": 163,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17618,6 +18596,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17636,6 +18615,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17654,6 +18634,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17672,6 +18653,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17690,6 +18672,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17708,6 +18691,7 @@
 		"songID": 164,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17726,6 +18710,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17744,6 +18729,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17762,6 +18748,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17780,6 +18767,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17798,6 +18786,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17816,6 +18805,7 @@
 		"songID": 165,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17834,6 +18824,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17852,6 +18843,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17870,6 +18862,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17888,6 +18881,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17906,6 +18900,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17924,6 +18919,7 @@
 		"songID": 166,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17942,6 +18938,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17960,6 +18957,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17978,6 +18976,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -17996,6 +18995,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18014,6 +19014,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18032,6 +19033,7 @@
 		"songID": 167,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18050,6 +19052,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18068,6 +19071,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18086,6 +19090,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18104,6 +19109,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18122,6 +19128,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18140,6 +19147,7 @@
 		"songID": 168,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18158,6 +19166,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18176,6 +19185,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18194,6 +19204,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18212,6 +19223,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18230,6 +19242,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18248,6 +19261,7 @@
 		"songID": 169,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18266,6 +19280,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18284,6 +19299,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18302,6 +19318,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18320,6 +19337,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18338,6 +19356,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18356,6 +19375,7 @@
 		"songID": 170,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18374,6 +19394,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18392,6 +19413,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18410,6 +19432,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18428,6 +19451,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18446,6 +19470,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18464,6 +19489,7 @@
 		"songID": 171,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18482,6 +19508,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18500,6 +19527,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18518,6 +19546,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18536,6 +19565,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18554,6 +19584,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18572,6 +19603,7 @@
 		"songID": 172,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18590,6 +19622,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18608,6 +19641,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18626,6 +19660,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18644,6 +19679,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18662,6 +19698,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18680,6 +19717,7 @@
 		"songID": 173,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18698,6 +19736,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18716,6 +19755,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18734,6 +19774,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18752,6 +19793,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18770,6 +19812,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18788,6 +19831,7 @@
 		"songID": 174,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18806,6 +19850,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18824,6 +19869,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18842,6 +19888,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18860,6 +19907,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18878,6 +19926,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18896,6 +19945,7 @@
 		"songID": 175,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18914,6 +19964,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18932,6 +19983,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18950,6 +20002,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18968,6 +20021,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -18986,6 +20040,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19004,6 +20059,7 @@
 		"songID": 176,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19022,6 +20078,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19040,6 +20097,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19058,6 +20116,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19076,6 +20135,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19094,6 +20154,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19112,6 +20173,7 @@
 		"songID": 177,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19130,6 +20192,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19148,6 +20211,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19166,6 +20230,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19184,6 +20249,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19202,6 +20268,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19220,6 +20287,7 @@
 		"songID": 178,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19238,6 +20306,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19256,6 +20325,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19274,6 +20344,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19292,6 +20363,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19310,6 +20382,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19328,6 +20401,7 @@
 		"songID": 179,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19346,6 +20420,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19364,6 +20439,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19382,6 +20458,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19400,6 +20477,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19418,6 +20496,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19436,6 +20515,7 @@
 		"songID": 180,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19454,6 +20534,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19472,6 +20553,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19490,6 +20572,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19508,6 +20591,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19526,6 +20610,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19544,6 +20629,7 @@
 		"songID": 181,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19562,6 +20648,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19580,6 +20667,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19598,6 +20686,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19616,6 +20705,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19634,6 +20724,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19652,6 +20743,7 @@
 		"songID": 182,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19670,6 +20762,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19688,6 +20781,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19706,6 +20800,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19724,6 +20819,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19742,6 +20838,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19760,6 +20857,7 @@
 		"songID": 183,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19778,6 +20876,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19796,6 +20895,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19814,6 +20914,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19832,6 +20933,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19850,6 +20952,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19868,6 +20971,7 @@
 		"songID": 184,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19886,6 +20990,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19904,6 +21009,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19922,6 +21028,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19940,6 +21047,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19958,6 +21066,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19976,6 +21085,7 @@
 		"songID": 185,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -19994,6 +21104,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20012,6 +21123,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20030,6 +21142,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20048,6 +21161,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20066,6 +21180,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20084,6 +21199,7 @@
 		"songID": 186,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20102,6 +21218,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20120,6 +21237,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20138,6 +21256,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20156,6 +21275,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20174,6 +21294,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20192,6 +21313,7 @@
 		"songID": 187,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20210,6 +21332,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20228,6 +21351,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20246,6 +21370,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20264,6 +21389,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20282,6 +21408,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20300,6 +21427,7 @@
 		"songID": 188,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20318,6 +21446,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20336,6 +21465,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20354,6 +21484,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20372,6 +21503,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20390,6 +21522,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20408,6 +21541,7 @@
 		"songID": 189,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20426,6 +21560,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20444,6 +21579,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20462,6 +21598,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20480,6 +21617,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20498,6 +21636,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20516,6 +21655,7 @@
 		"songID": 190,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20534,6 +21674,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20552,6 +21693,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20570,6 +21712,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20588,6 +21731,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20606,6 +21750,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20624,6 +21769,7 @@
 		"songID": 191,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20642,6 +21788,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20660,6 +21807,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20678,6 +21826,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20696,6 +21845,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20714,6 +21864,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20732,6 +21883,7 @@
 		"songID": 192,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20750,6 +21902,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20768,6 +21921,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20786,6 +21940,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20804,6 +21959,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20822,6 +21978,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20840,6 +21997,7 @@
 		"songID": 193,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20858,6 +22016,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20876,6 +22035,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20894,6 +22054,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20912,6 +22073,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20930,6 +22092,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20948,6 +22111,7 @@
 		"songID": 194,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20966,6 +22130,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -20984,6 +22149,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21002,6 +22168,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21020,6 +22187,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21038,6 +22206,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21056,6 +22225,7 @@
 		"songID": 195,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21074,6 +22244,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21092,6 +22263,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21110,6 +22282,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21128,6 +22301,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21146,6 +22320,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21164,6 +22339,7 @@
 		"songID": 196,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21182,6 +22358,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21200,6 +22377,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21218,6 +22396,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21236,6 +22415,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21254,6 +22434,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21272,6 +22453,7 @@
 		"songID": 197,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21290,6 +22472,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21308,6 +22491,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21326,6 +22510,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21344,6 +22529,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21362,6 +22548,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21380,6 +22567,7 @@
 		"songID": 198,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21398,6 +22586,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21416,6 +22605,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21434,6 +22624,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21452,6 +22643,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21470,6 +22662,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21488,6 +22681,7 @@
 		"songID": 199,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21506,6 +22700,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21524,6 +22719,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21542,6 +22738,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21560,6 +22757,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21578,6 +22776,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21596,6 +22795,7 @@
 		"songID": 200,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21614,6 +22814,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21632,6 +22833,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21650,6 +22852,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21668,6 +22871,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21686,6 +22890,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21704,6 +22909,7 @@
 		"songID": 201,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21722,6 +22928,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21740,6 +22947,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21758,6 +22966,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21776,6 +22985,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21794,6 +23004,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21812,6 +23023,7 @@
 		"songID": 202,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21830,6 +23042,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21848,6 +23061,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21866,6 +23080,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21884,6 +23099,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21902,6 +23118,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21920,6 +23137,7 @@
 		"songID": 203,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21938,6 +23156,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21956,6 +23175,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21974,6 +23194,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -21992,6 +23213,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22010,6 +23232,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22028,6 +23251,7 @@
 		"songID": 204,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22046,6 +23270,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22064,6 +23289,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22082,6 +23308,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22100,6 +23327,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22118,6 +23346,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22136,6 +23365,7 @@
 		"songID": 205,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22154,6 +23384,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22172,6 +23403,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22190,6 +23422,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22208,6 +23441,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22226,6 +23460,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22244,6 +23479,7 @@
 		"songID": 206,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22262,6 +23498,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22280,6 +23517,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22298,6 +23536,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22316,6 +23555,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22334,6 +23574,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22352,6 +23593,7 @@
 		"songID": 207,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22370,6 +23612,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22388,6 +23631,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22406,6 +23650,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22424,6 +23669,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22442,6 +23688,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22460,6 +23707,7 @@
 		"songID": 208,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22478,6 +23726,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22496,6 +23745,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22514,6 +23764,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22532,6 +23783,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22550,6 +23802,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22568,6 +23821,7 @@
 		"songID": 209,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22586,6 +23840,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22604,6 +23859,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22622,6 +23878,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22640,6 +23897,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22658,6 +23916,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22676,6 +23935,7 @@
 		"songID": 210,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22694,6 +23954,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22712,6 +23973,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22730,6 +23992,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22748,6 +24011,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22766,6 +24030,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22784,6 +24049,7 @@
 		"songID": 211,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22802,6 +24068,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22820,6 +24087,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22838,6 +24106,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22856,6 +24125,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22874,6 +24144,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22892,6 +24163,7 @@
 		"songID": 212,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22910,6 +24182,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22928,6 +24201,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22946,6 +24220,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22964,6 +24239,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -22982,6 +24258,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23000,6 +24277,7 @@
 		"songID": 213,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23018,6 +24296,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23036,6 +24315,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23054,6 +24334,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23072,6 +24353,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23090,6 +24372,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23108,6 +24391,7 @@
 		"songID": 214,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23126,6 +24410,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23144,6 +24429,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23162,6 +24448,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23180,6 +24467,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23198,6 +24486,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23216,6 +24505,7 @@
 		"songID": 215,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23234,6 +24524,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23252,6 +24543,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23270,6 +24562,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23288,6 +24581,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23306,6 +24600,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23324,6 +24619,7 @@
 		"songID": 216,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23342,6 +24638,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23360,6 +24657,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23378,6 +24676,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23396,6 +24695,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23414,6 +24714,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23432,6 +24733,7 @@
 		"songID": 217,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23450,6 +24752,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23468,6 +24771,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23486,6 +24790,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23504,6 +24809,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23522,6 +24828,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23540,6 +24847,7 @@
 		"songID": 218,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23558,6 +24866,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23576,6 +24885,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23594,6 +24904,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23612,6 +24923,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23630,6 +24942,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23648,6 +24961,7 @@
 		"songID": 219,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23666,6 +24980,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23684,6 +24999,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23702,6 +25018,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23720,6 +25037,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23738,6 +25056,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23756,6 +25075,7 @@
 		"songID": 220,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23774,6 +25094,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23792,6 +25113,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23810,6 +25132,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23828,6 +25151,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23846,6 +25170,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23864,6 +25189,7 @@
 		"songID": 221,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23882,6 +25208,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23900,6 +25227,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23918,6 +25246,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23936,6 +25265,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23954,6 +25284,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23972,6 +25303,7 @@
 		"songID": 222,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -23990,6 +25322,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24008,6 +25341,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24026,6 +25360,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24044,6 +25379,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24062,6 +25398,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24080,6 +25417,7 @@
 		"songID": 223,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24098,6 +25436,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24116,6 +25455,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24134,6 +25474,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24152,6 +25493,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24170,6 +25512,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24188,6 +25531,7 @@
 		"songID": 224,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24206,6 +25550,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24224,6 +25569,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24242,6 +25588,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24260,6 +25607,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24278,6 +25626,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24296,6 +25645,7 @@
 		"songID": 225,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24314,6 +25664,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24332,6 +25683,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24350,6 +25702,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24368,6 +25721,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24386,6 +25740,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24404,6 +25759,7 @@
 		"songID": 226,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24422,6 +25778,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24440,6 +25797,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24458,6 +25816,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24476,6 +25835,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24494,6 +25854,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24512,6 +25873,7 @@
 		"songID": 227,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24530,6 +25892,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24548,6 +25911,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24566,6 +25930,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24584,6 +25949,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24602,6 +25968,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24620,6 +25987,7 @@
 		"songID": 228,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24638,6 +26006,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24656,6 +26025,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24674,6 +26044,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24692,6 +26063,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24710,6 +26082,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24728,6 +26101,7 @@
 		"songID": 229,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24746,6 +26120,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24764,6 +26139,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24782,6 +26158,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24800,6 +26177,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24818,6 +26196,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24836,6 +26215,7 @@
 		"songID": 230,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24854,6 +26234,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24872,6 +26253,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24890,6 +26272,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24908,6 +26291,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24926,6 +26310,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24944,6 +26329,7 @@
 		"songID": 231,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24962,6 +26348,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24980,6 +26367,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -24998,6 +26386,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25016,6 +26405,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25034,6 +26424,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25052,6 +26443,7 @@
 		"songID": 232,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25070,6 +26462,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25088,6 +26481,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25106,6 +26500,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25124,6 +26519,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25142,6 +26538,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25160,6 +26557,7 @@
 		"songID": 233,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25178,6 +26576,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25196,6 +26595,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25214,6 +26614,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25232,6 +26633,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25250,6 +26652,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25268,6 +26671,7 @@
 		"songID": 234,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25286,6 +26690,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25304,6 +26709,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25322,6 +26728,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25340,6 +26747,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25358,6 +26766,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25376,6 +26785,7 @@
 		"songID": 235,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25394,6 +26804,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25412,6 +26823,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25430,6 +26842,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25448,6 +26861,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25466,6 +26880,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25484,6 +26899,7 @@
 		"songID": 236,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25502,6 +26918,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25520,6 +26937,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25538,6 +26956,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25556,6 +26975,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25574,6 +26994,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25592,6 +27013,7 @@
 		"songID": 237,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25610,6 +27032,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25628,6 +27051,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25646,6 +27070,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25664,6 +27089,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25682,6 +27108,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25700,6 +27127,7 @@
 		"songID": 238,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25718,6 +27146,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25736,6 +27165,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25754,6 +27184,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25772,6 +27203,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25790,6 +27222,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25808,6 +27241,7 @@
 		"songID": 239,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25826,6 +27260,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25844,6 +27279,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25862,6 +27298,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25880,6 +27317,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25898,6 +27336,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25916,6 +27355,7 @@
 		"songID": 240,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25934,6 +27374,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25952,6 +27393,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25970,6 +27412,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -25988,6 +27431,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26006,6 +27450,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26024,6 +27469,7 @@
 		"songID": 241,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26042,6 +27488,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26060,6 +27507,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26078,6 +27526,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26096,6 +27545,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26114,6 +27564,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26132,6 +27583,7 @@
 		"songID": 242,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26150,6 +27602,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26168,6 +27621,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26186,6 +27640,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26204,6 +27659,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26222,6 +27678,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26240,6 +27697,7 @@
 		"songID": 243,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26258,6 +27716,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26276,6 +27735,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26294,6 +27754,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26312,6 +27773,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26330,6 +27792,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26348,6 +27811,7 @@
 		"songID": 244,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26366,6 +27830,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26384,6 +27849,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26402,6 +27868,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26420,6 +27887,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26438,6 +27906,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26456,6 +27925,7 @@
 		"songID": 245,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26474,6 +27944,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26492,6 +27963,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26510,6 +27982,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26528,6 +28001,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26546,6 +28020,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26564,6 +28039,7 @@
 		"songID": 246,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26582,6 +28058,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26600,6 +28077,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26618,6 +28096,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26636,6 +28115,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26654,6 +28134,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26672,6 +28153,7 @@
 		"songID": 247,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26690,6 +28172,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26708,6 +28191,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26726,6 +28210,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26744,6 +28229,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26762,6 +28248,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26780,6 +28267,7 @@
 		"songID": 248,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26798,6 +28286,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26816,6 +28305,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26834,6 +28324,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26852,6 +28343,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26870,6 +28362,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26888,6 +28381,7 @@
 		"songID": 249,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26906,6 +28400,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26924,6 +28419,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26942,6 +28438,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26960,6 +28457,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26978,6 +28476,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -26996,6 +28495,7 @@
 		"songID": 250,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27014,6 +28514,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27032,6 +28533,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27050,6 +28552,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27068,6 +28571,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27086,6 +28590,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27104,6 +28609,7 @@
 		"songID": 251,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27122,6 +28628,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27140,6 +28647,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27158,6 +28666,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27176,6 +28685,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27194,6 +28704,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27212,6 +28723,7 @@
 		"songID": 252,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27230,6 +28742,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27248,6 +28761,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27266,6 +28780,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27284,6 +28799,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27302,6 +28818,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27320,6 +28837,7 @@
 		"songID": 253,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27338,6 +28856,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27356,6 +28875,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27374,6 +28894,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27392,6 +28913,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27410,6 +28932,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27428,6 +28951,7 @@
 		"songID": 254,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27446,6 +28970,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27464,6 +28989,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27482,6 +29008,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27500,6 +29027,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27518,6 +29046,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27536,6 +29065,7 @@
 		"songID": 255,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27554,6 +29084,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27572,6 +29103,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27590,6 +29122,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27608,6 +29141,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27626,6 +29160,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27644,6 +29179,7 @@
 		"songID": 256,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27662,6 +29198,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27680,6 +29217,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27698,6 +29236,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27716,6 +29255,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27734,6 +29274,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27752,6 +29293,7 @@
 		"songID": 257,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27770,6 +29312,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27788,6 +29331,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27806,6 +29350,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27824,6 +29369,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27842,6 +29388,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27860,6 +29407,7 @@
 		"songID": 258,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27878,6 +29426,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27896,6 +29445,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27914,6 +29464,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27932,6 +29483,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27950,6 +29502,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27968,6 +29521,7 @@
 		"songID": 259,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -27986,6 +29540,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28004,6 +29559,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28022,6 +29578,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28040,6 +29597,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28058,6 +29616,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28076,6 +29635,7 @@
 		"songID": 260,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28094,6 +29654,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28112,6 +29673,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28130,6 +29692,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28148,6 +29711,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28166,6 +29730,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28184,6 +29749,7 @@
 		"songID": 261,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28202,6 +29768,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28220,6 +29787,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28238,6 +29806,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28256,6 +29825,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28274,6 +29844,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28292,6 +29863,7 @@
 		"songID": 262,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28310,6 +29882,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28328,6 +29901,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28346,6 +29920,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28364,6 +29939,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28382,6 +29958,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28400,6 +29977,7 @@
 		"songID": 263,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28418,6 +29996,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28436,6 +30015,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28454,6 +30034,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28472,6 +30053,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28490,6 +30072,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28508,6 +30091,7 @@
 		"songID": 264,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28526,6 +30110,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28544,6 +30129,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28562,6 +30148,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28580,6 +30167,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28598,6 +30186,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28616,6 +30205,7 @@
 		"songID": 265,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28634,6 +30224,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28652,6 +30243,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28670,6 +30262,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28688,6 +30281,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28706,6 +30300,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28724,6 +30319,7 @@
 		"songID": 266,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28742,6 +30338,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28760,6 +30357,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28778,6 +30376,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28796,6 +30395,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28814,6 +30414,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28832,6 +30433,7 @@
 		"songID": 267,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28850,6 +30452,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28868,6 +30471,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28886,6 +30490,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28904,6 +30509,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28922,6 +30528,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28940,6 +30547,7 @@
 		"songID": 268,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28958,6 +30566,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28976,6 +30585,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -28994,6 +30604,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29012,6 +30623,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29030,6 +30642,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29048,6 +30661,7 @@
 		"songID": 269,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29066,6 +30680,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29084,6 +30699,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29102,6 +30718,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29120,6 +30737,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29138,6 +30756,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29156,6 +30775,7 @@
 		"songID": 270,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29174,6 +30794,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29192,6 +30813,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29210,6 +30832,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29228,6 +30851,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29246,6 +30870,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29264,6 +30889,7 @@
 		"songID": 271,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29282,6 +30908,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29300,6 +30927,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29318,6 +30946,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29336,6 +30965,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29354,6 +30984,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29372,6 +31003,7 @@
 		"songID": 272,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29390,6 +31022,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29408,6 +31041,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29426,6 +31060,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29444,6 +31079,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29462,6 +31098,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29480,6 +31117,7 @@
 		"songID": 273,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29498,6 +31136,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29516,6 +31155,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29534,6 +31174,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29552,6 +31193,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29570,6 +31212,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29588,6 +31231,7 @@
 		"songID": 274,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29606,6 +31250,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29624,6 +31269,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29642,6 +31288,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29660,6 +31307,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29678,6 +31326,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29696,6 +31345,7 @@
 		"songID": 275,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29714,6 +31364,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29732,6 +31383,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29750,6 +31402,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29768,6 +31421,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29786,6 +31440,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29804,6 +31459,7 @@
 		"songID": 276,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29822,6 +31478,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29840,6 +31497,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29858,6 +31516,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29876,6 +31535,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29894,6 +31554,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29912,6 +31573,7 @@
 		"songID": 277,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29930,6 +31592,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29948,6 +31611,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29966,6 +31630,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -29984,6 +31649,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30002,6 +31668,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30020,6 +31687,7 @@
 		"songID": 278,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30038,6 +31706,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30056,6 +31725,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30074,6 +31744,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30092,6 +31763,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30110,6 +31782,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30128,6 +31801,7 @@
 		"songID": 279,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30146,6 +31820,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30164,6 +31839,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30182,6 +31858,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30200,6 +31877,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30218,6 +31896,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30236,6 +31915,7 @@
 		"songID": 280,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30254,6 +31934,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30272,6 +31953,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30290,6 +31972,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30308,6 +31991,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30326,6 +32010,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30344,6 +32029,7 @@
 		"songID": 281,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30362,6 +32048,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30380,6 +32067,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30398,6 +32086,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30416,6 +32105,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30434,6 +32124,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30452,6 +32143,7 @@
 		"songID": 282,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30470,6 +32162,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30488,6 +32181,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30506,6 +32200,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30524,6 +32219,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30542,6 +32238,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30560,6 +32257,7 @@
 		"songID": 283,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30578,6 +32276,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30596,6 +32295,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30614,6 +32314,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30632,6 +32333,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30650,6 +32352,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30668,6 +32371,7 @@
 		"songID": 284,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30686,6 +32390,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30704,6 +32409,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30722,6 +32428,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30740,6 +32447,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30758,6 +32466,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30776,6 +32485,7 @@
 		"songID": 285,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30794,6 +32504,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30812,6 +32523,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30830,6 +32542,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30848,6 +32561,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30866,6 +32580,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30884,6 +32599,7 @@
 		"songID": 286,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30902,6 +32618,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30920,6 +32637,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30938,6 +32656,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30956,6 +32675,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30974,6 +32694,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -30992,6 +32713,7 @@
 		"songID": 287,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31010,6 +32732,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31028,6 +32751,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31046,6 +32770,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31064,6 +32789,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31082,6 +32808,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31100,6 +32827,7 @@
 		"songID": 288,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31118,6 +32846,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31136,6 +32865,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31154,6 +32884,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31172,6 +32903,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31190,6 +32922,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31208,6 +32941,7 @@
 		"songID": 289,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31226,6 +32960,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31244,6 +32979,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31262,6 +32998,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31280,6 +33017,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31298,6 +33036,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31316,6 +33055,7 @@
 		"songID": 290,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31334,6 +33074,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31352,6 +33093,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31370,6 +33112,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31388,6 +33131,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31406,6 +33150,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31424,6 +33169,7 @@
 		"songID": 291,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31442,6 +33188,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31460,6 +33207,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31478,6 +33226,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31496,6 +33245,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31514,6 +33264,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31532,6 +33283,7 @@
 		"songID": 292,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31550,6 +33302,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31568,6 +33321,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31586,6 +33340,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31604,6 +33359,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31622,6 +33378,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31640,6 +33397,7 @@
 		"songID": 293,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31658,6 +33416,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31676,6 +33435,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31694,6 +33454,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31712,6 +33473,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31730,6 +33492,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31748,6 +33511,7 @@
 		"songID": 294,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31766,6 +33530,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31784,6 +33549,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31802,6 +33568,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31820,6 +33587,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31838,6 +33606,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31856,6 +33625,7 @@
 		"songID": 295,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31874,6 +33644,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31892,6 +33663,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31910,6 +33682,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31928,6 +33701,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31946,6 +33720,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31964,6 +33739,7 @@
 		"songID": 296,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -31982,6 +33758,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32000,6 +33777,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32018,6 +33796,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32036,6 +33815,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32054,6 +33834,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32072,6 +33853,7 @@
 		"songID": 297,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32090,6 +33872,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32108,6 +33891,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32126,6 +33910,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32144,6 +33929,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32162,6 +33948,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32180,6 +33967,7 @@
 		"songID": 298,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32198,6 +33986,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32216,6 +34005,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32234,6 +34024,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32252,6 +34043,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32270,6 +34062,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32288,6 +34081,7 @@
 		"songID": 299,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32306,6 +34100,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32324,6 +34119,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32342,6 +34138,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32360,6 +34157,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32378,6 +34176,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32396,6 +34195,7 @@
 		"songID": 300,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32414,6 +34214,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32432,6 +34233,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32450,6 +34252,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32468,6 +34271,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32486,6 +34290,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32504,6 +34309,7 @@
 		"songID": 301,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32522,6 +34328,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32540,6 +34347,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32558,6 +34366,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32576,6 +34385,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32594,6 +34404,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32612,6 +34423,7 @@
 		"songID": 302,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32630,6 +34442,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32648,6 +34461,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32666,6 +34480,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32684,6 +34499,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32702,6 +34518,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32720,6 +34537,7 @@
 		"songID": 303,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32738,6 +34556,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32756,6 +34575,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32774,6 +34594,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32792,6 +34613,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32810,6 +34632,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32828,6 +34651,7 @@
 		"songID": 304,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32846,6 +34670,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32864,6 +34689,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32882,6 +34708,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32900,6 +34727,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32918,6 +34746,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32936,6 +34765,7 @@
 		"songID": 305,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32954,6 +34784,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32972,6 +34803,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -32990,6 +34822,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33008,6 +34841,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33026,6 +34860,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33044,6 +34879,7 @@
 		"songID": 306,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33062,6 +34898,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33080,6 +34917,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33098,6 +34936,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33116,6 +34955,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33134,6 +34974,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33152,6 +34993,7 @@
 		"songID": 307,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33170,6 +35012,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33188,6 +35031,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33206,6 +35050,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33224,6 +35069,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33242,6 +35088,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33260,6 +35107,7 @@
 		"songID": 308,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33278,6 +35126,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33296,6 +35145,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33314,6 +35164,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33332,6 +35183,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33350,6 +35202,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33368,6 +35221,7 @@
 		"songID": 309,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33386,6 +35240,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33404,6 +35259,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33422,6 +35278,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33440,6 +35297,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33458,6 +35316,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33476,6 +35335,7 @@
 		"songID": 310,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33494,6 +35354,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33512,6 +35373,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33530,6 +35392,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33548,6 +35411,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33566,6 +35430,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33584,6 +35449,7 @@
 		"songID": 311,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33602,6 +35468,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33620,6 +35487,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33638,6 +35506,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33656,6 +35525,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33674,6 +35544,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33692,6 +35563,7 @@
 		"songID": 312,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33710,6 +35582,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33728,6 +35601,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33746,6 +35620,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33764,6 +35639,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33782,6 +35658,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33800,6 +35677,7 @@
 		"songID": 313,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33818,6 +35696,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33836,6 +35715,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33854,6 +35734,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33872,6 +35753,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33890,6 +35772,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33908,6 +35791,7 @@
 		"songID": 314,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33926,6 +35810,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33944,6 +35829,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33962,6 +35848,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33980,6 +35867,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -33998,6 +35886,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34016,6 +35905,7 @@
 		"songID": 315,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34034,6 +35924,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34052,6 +35943,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34070,6 +35962,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34088,6 +35981,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34106,6 +36000,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34124,6 +36019,7 @@
 		"songID": 316,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34142,6 +36038,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34160,6 +36057,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34178,6 +36076,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34196,6 +36095,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34214,6 +36114,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34232,6 +36133,7 @@
 		"songID": 317,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34250,6 +36152,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34268,6 +36171,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34286,6 +36190,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34304,6 +36209,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34322,6 +36228,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34340,6 +36247,7 @@
 		"songID": 318,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34358,6 +36266,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34376,6 +36285,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34394,6 +36304,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34412,6 +36323,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34430,6 +36342,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34448,6 +36361,7 @@
 		"songID": 319,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34466,6 +36380,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34484,6 +36399,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34502,6 +36418,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34520,6 +36437,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34538,6 +36456,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34556,6 +36475,7 @@
 		"songID": 320,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34574,6 +36494,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34592,6 +36513,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34610,6 +36532,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34628,6 +36551,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34646,6 +36570,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34664,6 +36589,7 @@
 		"songID": 321,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34682,6 +36608,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34700,6 +36627,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34718,6 +36646,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34736,6 +36665,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34754,6 +36684,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34772,6 +36703,7 @@
 		"songID": 322,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34790,6 +36722,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34808,6 +36741,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34826,6 +36760,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34844,6 +36779,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34862,6 +36798,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34880,6 +36817,7 @@
 		"songID": 323,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34898,6 +36836,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34916,6 +36855,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34934,6 +36874,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34952,6 +36893,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34970,6 +36912,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -34988,6 +36931,7 @@
 		"songID": 324,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35006,6 +36950,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35024,6 +36969,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35042,6 +36988,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35060,6 +37007,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35078,6 +37026,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35096,6 +37045,7 @@
 		"songID": 325,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35114,6 +37064,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35132,6 +37083,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35150,6 +37102,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35168,6 +37121,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35186,6 +37140,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35204,6 +37159,7 @@
 		"songID": 326,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35222,6 +37178,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35240,6 +37197,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35258,6 +37216,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35276,6 +37235,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35294,6 +37254,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35312,6 +37273,7 @@
 		"songID": 327,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35330,6 +37292,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35348,6 +37311,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35366,6 +37330,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35384,6 +37349,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35402,6 +37368,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35420,6 +37387,7 @@
 		"songID": 328,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35438,6 +37406,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35456,6 +37425,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35474,6 +37444,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35492,6 +37463,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35510,6 +37482,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35528,6 +37501,7 @@
 		"songID": 329,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35546,6 +37520,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35564,6 +37539,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35582,6 +37558,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35600,6 +37577,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35618,6 +37596,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35636,6 +37615,7 @@
 		"songID": 330,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35654,6 +37634,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35672,6 +37653,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35690,6 +37672,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35708,6 +37691,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35726,6 +37710,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35744,6 +37729,7 @@
 		"songID": 331,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35762,6 +37748,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35780,6 +37767,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35798,6 +37786,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35816,6 +37805,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35834,6 +37824,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35852,6 +37843,7 @@
 		"songID": 332,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35870,6 +37862,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35888,6 +37881,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35906,6 +37900,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35924,6 +37919,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35942,6 +37938,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35960,6 +37957,7 @@
 		"songID": 333,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35978,6 +37976,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -35996,6 +37995,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36014,6 +38014,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36032,6 +38033,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36050,6 +38052,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36068,6 +38071,7 @@
 		"songID": 334,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36086,6 +38090,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36104,6 +38109,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36122,6 +38128,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36140,6 +38147,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36158,6 +38166,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36176,6 +38185,7 @@
 		"songID": 335,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36194,6 +38204,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36212,6 +38223,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36230,6 +38242,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36248,6 +38261,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36266,6 +38280,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36284,6 +38299,7 @@
 		"songID": 336,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36302,6 +38318,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36320,6 +38337,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36338,6 +38356,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36356,6 +38375,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36374,6 +38394,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36392,6 +38413,7 @@
 		"songID": 337,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36410,6 +38432,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36428,6 +38451,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36446,6 +38470,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36464,6 +38489,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36482,6 +38508,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36500,6 +38527,7 @@
 		"songID": 338,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36518,6 +38546,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36536,6 +38565,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36554,6 +38584,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36572,6 +38603,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36590,6 +38622,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36608,6 +38641,7 @@
 		"songID": 339,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36626,6 +38660,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36644,6 +38679,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36662,6 +38698,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36680,6 +38717,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36698,6 +38736,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36716,6 +38755,7 @@
 		"songID": 340,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36734,6 +38774,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36752,6 +38793,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36770,6 +38812,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36788,6 +38831,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36806,6 +38850,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36824,6 +38869,7 @@
 		"songID": 341,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36842,6 +38888,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36860,6 +38907,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36878,6 +38926,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36896,6 +38945,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36914,6 +38964,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36932,6 +38983,7 @@
 		"songID": 342,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36950,6 +39002,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36968,6 +39021,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -36986,6 +39040,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37004,6 +39059,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37022,6 +39078,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37040,6 +39097,7 @@
 		"songID": 343,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37058,6 +39116,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37076,6 +39135,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37094,6 +39154,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37112,6 +39173,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37130,6 +39192,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37148,6 +39211,7 @@
 		"songID": 344,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37166,6 +39230,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37184,6 +39249,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37202,6 +39268,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37220,6 +39287,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37238,6 +39306,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37256,6 +39325,7 @@
 		"songID": 345,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37274,6 +39344,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37292,6 +39363,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37310,6 +39382,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37328,6 +39401,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37346,6 +39420,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37364,6 +39439,7 @@
 		"songID": 346,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37382,6 +39458,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37400,6 +39477,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37418,6 +39496,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37436,6 +39515,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37454,6 +39534,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37472,6 +39553,7 @@
 		"songID": 347,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37490,6 +39572,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37508,6 +39591,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37526,6 +39610,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37544,6 +39629,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37562,6 +39648,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37580,6 +39667,7 @@
 		"songID": 348,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37598,6 +39686,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37616,6 +39705,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37634,6 +39724,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37652,6 +39743,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37670,6 +39762,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37688,6 +39781,7 @@
 		"songID": 349,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37706,6 +39800,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37724,6 +39819,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37742,6 +39838,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37760,6 +39857,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37778,6 +39876,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37796,6 +39895,7 @@
 		"songID": 350,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37814,6 +39914,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37832,6 +39933,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37850,6 +39952,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37868,6 +39971,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37886,6 +39990,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37904,6 +40009,7 @@
 		"songID": 351,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37922,6 +40028,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37940,6 +40047,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37958,6 +40066,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37976,6 +40085,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -37994,6 +40104,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38012,6 +40123,7 @@
 		"songID": 352,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38030,6 +40142,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38048,6 +40161,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38066,6 +40180,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38084,6 +40199,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38102,6 +40218,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38120,6 +40237,7 @@
 		"songID": 353,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38138,6 +40256,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38156,6 +40275,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38174,6 +40294,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38192,6 +40313,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38210,6 +40332,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38228,6 +40351,7 @@
 		"songID": 354,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38246,6 +40370,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38264,6 +40389,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38282,6 +40408,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38300,6 +40427,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38318,6 +40446,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38336,6 +40465,7 @@
 		"songID": 355,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38354,6 +40484,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38372,6 +40503,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38390,6 +40522,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38408,6 +40541,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38426,6 +40560,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38444,6 +40579,7 @@
 		"songID": 356,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38462,6 +40598,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38480,6 +40617,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38498,6 +40636,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38516,6 +40655,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38534,6 +40674,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38552,6 +40693,7 @@
 		"songID": 357,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38570,6 +40712,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38588,6 +40731,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38606,6 +40750,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38624,6 +40769,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38642,6 +40788,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38660,6 +40807,7 @@
 		"songID": 358,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38678,6 +40826,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38696,6 +40845,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38714,6 +40864,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38732,6 +40883,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38750,6 +40902,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38768,6 +40921,7 @@
 		"songID": 359,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38786,6 +40940,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38804,6 +40959,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38822,6 +40978,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38840,6 +40997,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38858,6 +41016,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38876,6 +41035,7 @@
 		"songID": 360,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38894,6 +41054,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38912,6 +41073,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38930,6 +41092,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38948,6 +41111,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38966,6 +41130,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -38984,6 +41149,7 @@
 		"songID": 361,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39002,6 +41168,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39020,6 +41187,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39038,6 +41206,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39056,6 +41225,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39074,6 +41244,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39092,6 +41263,7 @@
 		"songID": 362,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39110,6 +41282,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39128,6 +41301,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39146,6 +41320,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39164,6 +41339,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39182,6 +41358,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39200,6 +41377,7 @@
 		"songID": 363,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39218,6 +41396,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39236,6 +41415,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39254,6 +41434,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39272,6 +41453,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39290,6 +41472,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39308,6 +41491,7 @@
 		"songID": 364,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39326,6 +41510,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39344,6 +41529,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39362,6 +41548,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39380,6 +41567,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39398,6 +41586,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39416,6 +41605,7 @@
 		"songID": 365,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39434,6 +41624,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39452,6 +41643,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39470,6 +41662,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39488,6 +41681,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39506,6 +41700,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39524,6 +41719,7 @@
 		"songID": 366,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39542,6 +41738,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39560,6 +41757,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39578,6 +41776,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39596,6 +41795,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39614,6 +41814,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39632,6 +41833,7 @@
 		"songID": 367,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39650,6 +41852,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39668,6 +41871,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39686,6 +41890,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39704,6 +41909,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39722,6 +41928,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39740,6 +41947,7 @@
 		"songID": 368,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39758,6 +41966,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39776,6 +41985,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39794,6 +42004,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39812,6 +42023,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39830,6 +42042,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39848,6 +42061,7 @@
 		"songID": 369,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39866,6 +42080,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39884,6 +42099,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39902,6 +42118,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39920,6 +42137,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39938,6 +42156,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39956,6 +42175,7 @@
 		"songID": 370,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39974,6 +42194,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -39992,6 +42213,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40010,6 +42232,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40028,6 +42251,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40046,6 +42270,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40064,6 +42289,7 @@
 		"songID": 371,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40082,6 +42308,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40100,6 +42327,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40118,6 +42346,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40136,6 +42365,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40154,6 +42384,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40172,6 +42403,7 @@
 		"songID": 372,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40190,6 +42422,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40208,6 +42441,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40226,6 +42460,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40244,6 +42479,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40262,6 +42498,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40280,6 +42517,7 @@
 		"songID": 373,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40298,6 +42536,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40316,6 +42555,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40334,6 +42574,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40352,6 +42593,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40370,6 +42612,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40388,6 +42631,7 @@
 		"songID": 374,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40406,6 +42650,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40424,6 +42669,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40442,6 +42688,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40460,6 +42707,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40478,6 +42726,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40496,6 +42745,7 @@
 		"songID": 375,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40514,6 +42764,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40532,6 +42783,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40550,6 +42802,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40568,6 +42821,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40586,6 +42840,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40604,6 +42859,7 @@
 		"songID": 376,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40622,6 +42878,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40640,6 +42897,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40658,6 +42916,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40676,6 +42935,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40694,6 +42954,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40712,6 +42973,7 @@
 		"songID": 377,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40730,6 +42992,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40748,6 +43011,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40766,6 +43030,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40784,6 +43049,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40802,6 +43068,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40820,6 +43087,7 @@
 		"songID": 378,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40838,6 +43106,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40856,6 +43125,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40874,6 +43144,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40892,6 +43163,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40910,6 +43182,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40928,6 +43201,7 @@
 		"songID": 379,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40946,6 +43220,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40964,6 +43239,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -40982,6 +43258,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41000,6 +43277,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41018,6 +43296,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41036,6 +43315,7 @@
 		"songID": 380,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41054,6 +43334,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41072,6 +43353,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41090,6 +43372,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41108,6 +43391,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41126,6 +43410,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41144,6 +43429,7 @@
 		"songID": 381,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41162,6 +43448,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41180,6 +43467,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41198,6 +43486,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41216,6 +43505,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41234,6 +43524,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41252,6 +43543,7 @@
 		"songID": 382,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41270,6 +43562,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41288,6 +43581,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41306,6 +43600,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41324,6 +43619,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41342,6 +43638,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41360,6 +43657,7 @@
 		"songID": 383,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41378,6 +43676,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41396,6 +43695,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41414,6 +43714,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41432,6 +43733,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41450,6 +43752,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41468,6 +43771,7 @@
 		"songID": 384,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41486,6 +43790,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41504,6 +43809,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41522,6 +43828,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41540,6 +43847,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41558,6 +43866,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41576,6 +43885,7 @@
 		"songID": 385,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41594,6 +43904,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41612,6 +43923,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41630,6 +43942,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41648,6 +43961,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41666,6 +43980,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41684,6 +43999,7 @@
 		"songID": 386,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41702,6 +44018,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41720,6 +44037,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41738,6 +44056,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41756,6 +44075,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41774,6 +44094,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41792,6 +44113,7 @@
 		"songID": 387,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41810,6 +44132,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41828,6 +44151,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41846,6 +44170,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41864,6 +44189,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41882,6 +44208,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41900,6 +44227,7 @@
 		"songID": 388,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41918,6 +44246,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41936,6 +44265,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41954,6 +44284,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41972,6 +44303,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -41990,6 +44322,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42008,6 +44341,7 @@
 		"songID": 389,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42026,6 +44360,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42044,6 +44379,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42062,6 +44398,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42080,6 +44417,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42098,6 +44436,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42116,6 +44455,7 @@
 		"songID": 390,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42134,6 +44474,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42152,6 +44493,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42170,6 +44512,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42188,6 +44531,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42206,6 +44550,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42224,6 +44569,7 @@
 		"songID": 391,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42242,6 +44588,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42260,6 +44607,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42278,6 +44626,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42296,6 +44645,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42314,6 +44664,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42332,6 +44683,7 @@
 		"songID": 392,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42350,6 +44702,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42368,6 +44721,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42386,6 +44740,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42404,6 +44759,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42422,6 +44778,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42440,6 +44797,7 @@
 		"songID": 393,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42458,6 +44816,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42476,6 +44835,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42494,6 +44854,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42512,6 +44873,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42530,6 +44892,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42548,6 +44911,7 @@
 		"songID": 394,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42566,6 +44930,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42584,6 +44949,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42602,6 +44968,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42620,6 +44987,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42638,6 +45006,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42656,6 +45025,7 @@
 		"songID": 395,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42674,6 +45044,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42692,6 +45063,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42710,6 +45082,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42728,6 +45101,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42746,6 +45120,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42764,6 +45139,7 @@
 		"songID": 396,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42782,6 +45158,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42800,6 +45177,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42818,6 +45196,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42836,6 +45215,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42854,6 +45234,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42872,6 +45253,7 @@
 		"songID": 397,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42890,6 +45272,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42908,6 +45291,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42926,6 +45310,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42944,6 +45329,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42962,6 +45348,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42980,6 +45367,7 @@
 		"songID": 398,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -42998,6 +45386,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43016,6 +45405,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43034,6 +45424,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43052,6 +45443,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43070,6 +45462,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43088,6 +45481,7 @@
 		"songID": 399,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43106,6 +45500,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43124,6 +45519,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43142,6 +45538,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43160,6 +45557,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43178,6 +45576,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43196,6 +45595,7 @@
 		"songID": 400,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43214,6 +45614,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43232,6 +45633,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43250,6 +45652,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43268,6 +45671,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43286,6 +45690,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43304,6 +45709,7 @@
 		"songID": 401,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43322,6 +45728,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43340,6 +45747,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43358,6 +45766,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43376,6 +45785,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43394,6 +45804,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43412,6 +45823,7 @@
 		"songID": 402,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43430,6 +45842,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43448,6 +45861,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43466,6 +45880,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43484,6 +45899,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43502,6 +45918,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43520,6 +45937,7 @@
 		"songID": 403,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43538,6 +45956,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43556,6 +45975,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43574,6 +45994,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43592,6 +46013,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43610,6 +46032,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43628,6 +46051,7 @@
 		"songID": 404,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43646,6 +46070,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43664,6 +46089,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43682,6 +46108,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43700,6 +46127,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43718,6 +46146,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43736,6 +46165,7 @@
 		"songID": 405,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43754,6 +46184,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43772,6 +46203,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43790,6 +46222,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43808,6 +46241,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43826,6 +46260,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43844,6 +46279,7 @@
 		"songID": 406,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43862,6 +46298,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43880,6 +46317,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43898,6 +46336,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43916,6 +46355,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43934,6 +46374,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43952,6 +46393,7 @@
 		"songID": 407,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43970,6 +46412,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -43988,6 +46431,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44006,6 +46450,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44024,6 +46469,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44042,6 +46488,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44060,6 +46507,7 @@
 		"songID": 408,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44078,6 +46526,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44096,6 +46545,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44114,6 +46564,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44132,6 +46583,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44150,6 +46602,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44168,6 +46621,7 @@
 		"songID": 409,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44186,6 +46640,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44204,6 +46659,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44222,6 +46678,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44240,6 +46697,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44258,6 +46716,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44276,6 +46735,7 @@
 		"songID": 410,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44294,6 +46754,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44312,6 +46773,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44330,6 +46792,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44348,6 +46811,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44366,6 +46830,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44384,6 +46849,7 @@
 		"songID": 411,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44402,6 +46868,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44420,6 +46887,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44438,6 +46906,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44456,6 +46925,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44474,6 +46944,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44492,6 +46963,7 @@
 		"songID": 412,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44510,6 +46982,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44528,6 +47001,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44546,6 +47020,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44564,6 +47039,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44582,6 +47058,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44600,6 +47077,7 @@
 		"songID": 413,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44618,6 +47096,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44636,6 +47115,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44654,6 +47134,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44672,6 +47153,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44690,6 +47172,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44708,6 +47191,7 @@
 		"songID": 414,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44726,6 +47210,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44744,6 +47229,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44762,6 +47248,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44780,6 +47267,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44798,6 +47286,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44816,6 +47305,7 @@
 		"songID": 415,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44834,6 +47324,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44852,6 +47343,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44870,6 +47362,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44888,6 +47381,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44906,6 +47400,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44924,6 +47419,7 @@
 		"songID": 416,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44942,6 +47438,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44960,6 +47457,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44978,6 +47476,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -44996,6 +47495,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45014,6 +47514,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45032,6 +47533,7 @@
 		"songID": 417,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45050,6 +47552,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45068,6 +47571,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45086,6 +47590,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45104,6 +47609,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45122,6 +47628,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45140,6 +47647,7 @@
 		"songID": 418,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45158,6 +47666,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45176,6 +47685,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45194,6 +47704,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45212,6 +47723,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45230,6 +47742,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45248,6 +47761,7 @@
 		"songID": 419,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45266,6 +47780,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45284,6 +47799,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45302,6 +47818,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45320,6 +47837,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45338,6 +47856,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45356,6 +47875,7 @@
 		"songID": 420,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45374,6 +47894,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45392,6 +47913,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45410,6 +47932,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45428,6 +47951,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45446,6 +47970,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45464,6 +47989,7 @@
 		"songID": 421,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45482,6 +48008,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45500,6 +48027,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45518,6 +48046,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45536,6 +48065,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45554,6 +48084,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45572,6 +48103,7 @@
 		"songID": 422,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45590,6 +48122,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45608,6 +48141,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45626,6 +48160,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45644,6 +48179,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45662,6 +48198,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45680,6 +48217,7 @@
 		"songID": 423,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45698,6 +48236,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45716,6 +48255,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45734,6 +48274,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45752,6 +48293,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45770,6 +48312,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45788,6 +48331,7 @@
 		"songID": 424,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45806,6 +48350,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45824,6 +48369,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45842,6 +48388,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45860,6 +48407,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45878,6 +48426,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45896,6 +48445,7 @@
 		"songID": 425,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45914,6 +48464,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45932,6 +48483,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45950,6 +48502,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45968,6 +48521,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -45986,6 +48540,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46004,6 +48559,7 @@
 		"songID": 426,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46022,6 +48578,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46040,6 +48597,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46058,6 +48616,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46076,6 +48635,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46094,6 +48654,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46112,6 +48673,7 @@
 		"songID": 427,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46130,6 +48692,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46148,6 +48711,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46166,6 +48730,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46184,6 +48749,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46202,6 +48768,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46220,6 +48787,7 @@
 		"songID": 428,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46238,6 +48806,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46256,6 +48825,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46274,6 +48844,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46292,6 +48863,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46310,6 +48882,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46328,6 +48901,7 @@
 		"songID": 429,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46346,6 +48920,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46364,6 +48939,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46382,6 +48958,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46400,6 +48977,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46418,6 +48996,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46436,6 +49015,7 @@
 		"songID": 430,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46454,6 +49034,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46472,6 +49053,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46490,6 +49072,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46508,6 +49091,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46526,6 +49110,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46544,6 +49129,7 @@
 		"songID": 431,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46562,6 +49148,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46580,6 +49167,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46598,6 +49186,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46616,6 +49205,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46634,6 +49224,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46652,6 +49243,7 @@
 		"songID": 432,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46670,6 +49262,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46688,6 +49281,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46706,6 +49300,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46724,6 +49319,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46742,6 +49338,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46760,6 +49357,7 @@
 		"songID": 433,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46778,6 +49376,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46796,6 +49395,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46814,6 +49414,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46832,6 +49433,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46850,6 +49452,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46868,6 +49471,7 @@
 		"songID": 434,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46886,6 +49490,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46904,6 +49509,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46922,6 +49528,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46940,6 +49547,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46958,6 +49566,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46976,6 +49585,7 @@
 		"songID": 435,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -46994,6 +49604,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47012,6 +49623,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47030,6 +49642,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47048,6 +49661,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47066,6 +49680,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47084,6 +49699,7 @@
 		"songID": 436,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47102,6 +49718,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47120,6 +49737,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47138,6 +49756,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47156,6 +49775,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47174,6 +49794,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47192,6 +49813,7 @@
 		"songID": 437,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47210,6 +49832,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47228,6 +49851,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47246,6 +49870,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47264,6 +49889,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47282,6 +49908,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47300,6 +49927,7 @@
 		"songID": 438,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47318,6 +49946,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47336,6 +49965,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47354,6 +49984,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47372,6 +50003,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47390,6 +50022,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47408,6 +50041,7 @@
 		"songID": 439,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47426,6 +50060,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47444,6 +50079,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47462,6 +50098,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47480,6 +50117,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47498,6 +50136,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47516,6 +50155,7 @@
 		"songID": 440,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47534,6 +50174,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47552,6 +50193,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47570,6 +50212,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47588,6 +50231,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47606,6 +50250,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47624,6 +50269,7 @@
 		"songID": 441,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47642,6 +50288,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47660,6 +50307,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47678,6 +50326,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47696,6 +50345,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47714,6 +50364,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47732,6 +50383,7 @@
 		"songID": 442,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47750,6 +50402,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47768,6 +50421,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47786,6 +50440,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47804,6 +50459,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47822,6 +50478,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47840,6 +50497,7 @@
 		"songID": 443,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47858,6 +50516,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47876,6 +50535,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47894,6 +50554,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47912,6 +50573,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47930,6 +50592,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47948,6 +50611,7 @@
 		"songID": 444,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47966,6 +50630,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -47984,6 +50649,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48002,6 +50668,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48020,6 +50687,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48038,6 +50706,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48056,6 +50725,7 @@
 		"songID": 445,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48074,6 +50744,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48092,6 +50763,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48110,6 +50782,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48128,6 +50801,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48146,6 +50820,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48164,6 +50839,7 @@
 		"songID": 446,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48182,6 +50858,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48200,6 +50877,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48218,6 +50896,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48236,6 +50915,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48254,6 +50934,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48272,6 +50953,7 @@
 		"songID": 447,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48290,6 +50972,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48308,6 +50991,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48326,6 +51010,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48344,6 +51029,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48362,6 +51048,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48380,6 +51067,7 @@
 		"songID": 448,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48398,6 +51086,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48416,6 +51105,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48434,6 +51124,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48452,6 +51143,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48470,6 +51162,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48488,6 +51181,7 @@
 		"songID": 449,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48506,6 +51200,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48524,6 +51219,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48542,6 +51238,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48560,6 +51257,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48578,6 +51276,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48596,6 +51295,7 @@
 		"songID": 450,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48614,6 +51314,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48632,6 +51333,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48650,6 +51352,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48668,6 +51371,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48686,6 +51390,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48704,6 +51409,7 @@
 		"songID": 451,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48722,6 +51428,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48740,6 +51447,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48758,6 +51466,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48776,6 +51485,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48794,6 +51504,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48812,6 +51523,7 @@
 		"songID": 452,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48830,6 +51542,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48848,6 +51561,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48866,6 +51580,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48884,6 +51599,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48902,6 +51618,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48920,6 +51637,7 @@
 		"songID": 453,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48938,6 +51656,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48956,6 +51675,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48974,6 +51694,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -48992,6 +51713,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49010,6 +51732,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49028,6 +51751,7 @@
 		"songID": 454,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49046,6 +51770,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49064,6 +51789,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49082,6 +51808,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49100,6 +51827,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49118,6 +51846,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49136,6 +51865,7 @@
 		"songID": 455,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49154,6 +51884,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49172,6 +51903,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49190,6 +51922,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49208,6 +51941,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49226,6 +51960,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49244,6 +51979,7 @@
 		"songID": 456,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49262,6 +51998,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49280,6 +52017,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49298,6 +52036,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49316,6 +52055,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49334,6 +52074,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49352,6 +52093,7 @@
 		"songID": 457,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49370,6 +52112,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49388,6 +52131,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49406,6 +52150,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49424,6 +52169,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49442,6 +52188,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49460,6 +52207,7 @@
 		"songID": 458,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49478,6 +52226,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49496,6 +52245,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49514,6 +52264,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49532,6 +52283,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49550,6 +52302,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49568,6 +52321,7 @@
 		"songID": 459,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49586,6 +52340,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49604,6 +52359,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49622,6 +52378,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49640,6 +52397,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49658,6 +52416,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49676,6 +52435,7 @@
 		"songID": 460,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49694,6 +52454,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49712,6 +52473,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49730,6 +52492,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49748,6 +52511,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49766,6 +52530,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49784,6 +52549,7 @@
 		"songID": 461,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49802,6 +52568,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49820,6 +52587,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49838,6 +52606,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49856,6 +52625,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49874,6 +52644,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49892,6 +52663,7 @@
 		"songID": 462,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49910,6 +52682,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49928,6 +52701,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49946,6 +52720,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49964,6 +52739,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -49982,6 +52758,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50000,6 +52777,7 @@
 		"songID": 463,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50018,6 +52796,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50036,6 +52815,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50054,6 +52834,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50072,6 +52853,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50090,6 +52872,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50108,6 +52891,7 @@
 		"songID": 464,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50126,6 +52910,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50144,6 +52929,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50162,6 +52948,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50180,6 +52967,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50198,6 +52986,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50216,6 +53005,7 @@
 		"songID": 465,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50234,6 +53024,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50252,6 +53043,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50270,6 +53062,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50288,6 +53081,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50306,6 +53100,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50324,6 +53119,7 @@
 		"songID": 466,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50342,6 +53138,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50360,6 +53157,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50378,6 +53176,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50396,6 +53195,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50414,6 +53214,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50432,6 +53233,7 @@
 		"songID": 467,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50450,6 +53252,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50468,6 +53271,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50486,6 +53290,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50504,6 +53309,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50522,6 +53328,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50540,6 +53347,7 @@
 		"songID": 468,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50558,6 +53366,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50576,6 +53385,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50594,6 +53404,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50612,6 +53423,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50630,6 +53442,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50648,6 +53461,7 @@
 		"songID": 469,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50666,6 +53480,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50684,6 +53499,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50702,6 +53518,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50720,6 +53537,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50738,6 +53556,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50756,6 +53575,7 @@
 		"songID": 470,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50774,6 +53594,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50792,6 +53613,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50810,6 +53632,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50828,6 +53651,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50846,6 +53670,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50864,6 +53689,7 @@
 		"songID": 471,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50882,6 +53708,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50900,6 +53727,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50918,6 +53746,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50936,6 +53765,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50954,6 +53784,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50972,6 +53803,7 @@
 		"songID": 472,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -50990,6 +53822,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51008,6 +53841,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51026,6 +53860,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51044,6 +53879,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51062,6 +53898,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51080,6 +53917,7 @@
 		"songID": 473,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51098,6 +53936,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51116,6 +53955,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51134,6 +53974,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51152,6 +53993,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51170,6 +54012,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51188,6 +54031,7 @@
 		"songID": 474,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51206,6 +54050,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51224,6 +54069,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51242,6 +54088,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51260,6 +54107,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51278,6 +54126,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51296,6 +54145,7 @@
 		"songID": 475,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51314,6 +54164,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51332,6 +54183,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51350,6 +54202,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51368,6 +54221,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51386,6 +54240,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51404,6 +54259,7 @@
 		"songID": 476,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51422,6 +54278,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51440,6 +54297,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51458,6 +54316,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51476,6 +54335,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51494,6 +54354,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51512,6 +54373,7 @@
 		"songID": 477,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51530,6 +54392,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51548,6 +54411,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51566,6 +54430,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51584,6 +54449,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51602,6 +54468,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51620,6 +54487,7 @@
 		"songID": 478,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51638,6 +54506,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51656,6 +54525,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51674,6 +54544,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51692,6 +54563,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51710,6 +54582,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51728,6 +54601,7 @@
 		"songID": 479,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51746,6 +54620,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51764,6 +54639,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51782,6 +54658,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51800,6 +54677,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51818,6 +54696,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51836,6 +54715,7 @@
 		"songID": 480,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51854,6 +54734,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51872,6 +54753,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51890,6 +54772,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51908,6 +54791,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51926,6 +54810,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51944,6 +54829,7 @@
 		"songID": 481,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51962,6 +54848,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51980,6 +54867,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -51998,6 +54886,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52016,6 +54905,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52034,6 +54924,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52052,6 +54943,7 @@
 		"songID": 482,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52070,6 +54962,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52088,6 +54981,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52106,6 +55000,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52124,6 +55019,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52142,6 +55038,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52160,6 +55057,7 @@
 		"songID": 483,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52178,6 +55076,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52196,6 +55095,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52214,6 +55114,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52232,6 +55133,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52250,6 +55152,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52268,6 +55171,7 @@
 		"songID": 484,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52286,6 +55190,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52304,6 +55209,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52322,6 +55228,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52340,6 +55247,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52358,6 +55266,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52376,6 +55285,7 @@
 		"songID": 485,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52394,6 +55304,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52412,6 +55323,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52430,6 +55342,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52448,6 +55361,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52466,6 +55380,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52484,6 +55399,7 @@
 		"songID": 486,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52502,6 +55418,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52520,6 +55437,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52538,6 +55456,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52556,6 +55475,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52574,6 +55494,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52592,6 +55513,7 @@
 		"songID": 487,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52610,6 +55532,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52628,6 +55551,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52646,6 +55570,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52664,6 +55589,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52682,6 +55608,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52700,6 +55627,7 @@
 		"songID": 488,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52718,6 +55646,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52736,6 +55665,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52754,6 +55684,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52772,6 +55703,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52790,6 +55722,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52808,6 +55741,7 @@
 		"songID": 489,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52826,6 +55760,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52844,6 +55779,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52862,6 +55798,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52880,6 +55817,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52898,6 +55836,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52916,6 +55855,7 @@
 		"songID": 490,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52934,6 +55874,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52952,6 +55893,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52970,6 +55912,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -52988,6 +55931,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53006,6 +55950,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53024,6 +55969,7 @@
 		"songID": 491,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53042,6 +55988,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53060,6 +56007,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53078,6 +56026,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53096,6 +56045,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53114,6 +56064,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53132,6 +56083,7 @@
 		"songID": 492,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53150,6 +56102,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53168,6 +56121,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53186,6 +56140,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53204,6 +56159,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53222,6 +56178,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53240,6 +56197,7 @@
 		"songID": 493,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53258,6 +56216,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53276,6 +56235,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53294,6 +56254,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53312,6 +56273,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53330,6 +56292,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53348,6 +56311,7 @@
 		"songID": 494,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53366,6 +56330,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53384,6 +56349,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53402,6 +56368,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53420,6 +56387,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53438,6 +56406,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53456,6 +56425,7 @@
 		"songID": 495,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53474,6 +56444,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53492,6 +56463,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53510,6 +56482,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53528,6 +56501,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53546,6 +56520,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53564,6 +56539,7 @@
 		"songID": 496,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53582,6 +56558,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53600,6 +56577,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53618,6 +56596,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53636,6 +56615,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53654,6 +56634,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53672,6 +56653,7 @@
 		"songID": 497,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53690,6 +56672,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53708,6 +56691,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53726,6 +56710,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53744,6 +56729,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53762,6 +56748,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53780,6 +56767,7 @@
 		"songID": 498,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53798,6 +56786,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53816,6 +56805,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53834,6 +56824,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53852,6 +56843,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53870,6 +56862,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53888,6 +56881,7 @@
 		"songID": 499,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53906,6 +56900,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53924,6 +56919,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53942,6 +56938,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53960,6 +56957,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53978,6 +56976,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -53996,6 +56995,7 @@
 		"songID": 500,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54014,6 +57014,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54032,6 +57033,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54050,6 +57052,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54068,6 +57071,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54086,6 +57090,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54104,6 +57109,7 @@
 		"songID": 501,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54122,6 +57128,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54140,6 +57147,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54158,6 +57166,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54176,6 +57185,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54194,6 +57204,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54212,6 +57223,7 @@
 		"songID": 502,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54230,6 +57242,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54248,6 +57261,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54266,6 +57280,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54284,6 +57299,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54302,6 +57318,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54320,6 +57337,7 @@
 		"songID": 503,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54338,6 +57356,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54356,6 +57375,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54374,6 +57394,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54392,6 +57413,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54410,6 +57432,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54428,6 +57451,7 @@
 		"songID": 504,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54446,6 +57470,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54464,6 +57489,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54482,6 +57508,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54500,6 +57527,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54518,6 +57546,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54536,6 +57565,7 @@
 		"songID": 505,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54554,6 +57584,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54572,6 +57603,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54590,6 +57622,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54608,6 +57641,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54626,6 +57660,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54644,6 +57679,7 @@
 		"songID": 506,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54662,6 +57698,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54680,6 +57717,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54698,6 +57736,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54716,6 +57755,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54734,6 +57774,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54752,6 +57793,7 @@
 		"songID": 507,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54770,6 +57812,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54788,6 +57831,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54806,6 +57850,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54824,6 +57869,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54842,6 +57888,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54860,6 +57907,7 @@
 		"songID": 508,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54878,6 +57926,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54896,6 +57945,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54914,6 +57964,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54932,6 +57983,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54950,6 +58002,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54968,6 +58021,7 @@
 		"songID": 509,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -54986,6 +58040,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55004,6 +58059,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55022,6 +58078,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55040,6 +58097,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55058,6 +58116,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55076,6 +58135,7 @@
 		"songID": 510,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55094,6 +58154,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55112,6 +58173,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55130,6 +58192,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55148,6 +58211,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55166,6 +58230,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55184,6 +58249,7 @@
 		"songID": 511,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55202,6 +58268,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55220,6 +58287,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55238,6 +58306,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55256,6 +58325,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55274,6 +58344,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55292,6 +58363,7 @@
 		"songID": 512,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55310,6 +58382,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55328,6 +58401,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55346,6 +58420,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55364,6 +58439,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55382,6 +58458,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55400,6 +58477,7 @@
 		"songID": 513,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55418,6 +58496,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55436,6 +58515,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55454,6 +58534,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55472,6 +58553,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55490,6 +58572,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55508,6 +58591,7 @@
 		"songID": 514,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55526,6 +58610,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55544,6 +58629,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55562,6 +58648,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55580,6 +58667,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55598,6 +58686,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55616,6 +58705,7 @@
 		"songID": 515,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55634,6 +58724,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55652,6 +58743,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55670,6 +58762,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55688,6 +58781,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55706,6 +58800,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55724,6 +58819,7 @@
 		"songID": 516,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55742,6 +58838,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55760,6 +58857,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55778,6 +58876,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55796,6 +58895,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55814,6 +58914,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55832,6 +58933,7 @@
 		"songID": 517,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55850,6 +58952,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55868,6 +58971,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55886,6 +58990,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55904,6 +59009,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55922,6 +59028,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55940,6 +59047,7 @@
 		"songID": 518,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55958,6 +59066,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55976,6 +59085,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -55994,6 +59104,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56012,6 +59123,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56030,6 +59142,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56048,6 +59161,7 @@
 		"songID": 519,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56066,6 +59180,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56084,6 +59199,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56102,6 +59218,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56120,6 +59237,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56138,6 +59256,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56156,6 +59275,7 @@
 		"songID": 520,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56174,6 +59294,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56192,6 +59313,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56210,6 +59332,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56228,6 +59351,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56246,6 +59370,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56264,6 +59389,7 @@
 		"songID": 521,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56282,6 +59408,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56300,6 +59427,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56318,6 +59446,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56336,6 +59465,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56354,6 +59484,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56372,6 +59503,7 @@
 		"songID": 522,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56390,6 +59522,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56408,6 +59541,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56426,6 +59560,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56444,6 +59579,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56462,6 +59598,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56480,6 +59617,7 @@
 		"songID": 523,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56498,6 +59636,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56516,6 +59655,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56534,6 +59674,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56552,6 +59693,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56570,6 +59712,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56588,6 +59731,7 @@
 		"songID": 524,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56606,6 +59750,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56624,6 +59769,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56642,6 +59788,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56660,6 +59807,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56678,6 +59826,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56696,6 +59845,7 @@
 		"songID": 525,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56714,6 +59864,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56732,6 +59883,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56750,6 +59902,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56768,6 +59921,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56786,6 +59940,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56804,6 +59959,7 @@
 		"songID": 526,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56822,6 +59978,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56840,6 +59997,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56858,6 +60016,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56876,6 +60035,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56894,6 +60054,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56912,6 +60073,7 @@
 		"songID": 527,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56930,6 +60092,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56948,6 +60111,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56966,6 +60130,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -56984,6 +60149,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57002,6 +60168,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57020,6 +60187,7 @@
 		"songID": 528,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57038,6 +60206,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57056,6 +60225,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57074,6 +60244,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57092,6 +60263,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57110,6 +60282,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57128,6 +60301,7 @@
 		"songID": 529,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57146,6 +60320,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57164,6 +60339,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57182,6 +60358,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57200,6 +60377,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57218,6 +60396,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57236,6 +60415,7 @@
 		"songID": 530,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57254,6 +60434,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57272,6 +60453,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57290,6 +60472,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57308,6 +60491,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57326,6 +60510,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57344,6 +60529,7 @@
 		"songID": 531,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57362,6 +60548,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57380,6 +60567,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57398,6 +60586,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57416,6 +60605,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57434,6 +60624,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57452,6 +60643,7 @@
 		"songID": 532,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57470,6 +60662,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57488,6 +60681,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57506,6 +60700,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57524,6 +60719,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57542,6 +60738,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57560,6 +60757,7 @@
 		"songID": 533,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57578,6 +60776,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57596,6 +60795,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57614,6 +60814,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57632,6 +60833,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57650,6 +60852,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57668,6 +60871,7 @@
 		"songID": 534,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57686,6 +60890,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57704,6 +60909,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57722,6 +60928,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57740,6 +60947,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57758,6 +60966,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57776,6 +60985,7 @@
 		"songID": 535,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57794,6 +61004,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57812,6 +61023,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57830,6 +61042,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57848,6 +61061,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57866,6 +61080,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57884,6 +61099,7 @@
 		"songID": 536,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57902,6 +61118,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57920,6 +61137,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57938,6 +61156,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57956,6 +61175,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57974,6 +61194,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -57992,6 +61213,7 @@
 		"songID": 537,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58010,6 +61232,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58028,6 +61251,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58046,6 +61270,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58064,6 +61289,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58082,6 +61308,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58100,6 +61327,7 @@
 		"songID": 538,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58118,6 +61346,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58136,6 +61365,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58154,6 +61384,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58172,6 +61403,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58190,6 +61422,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58208,6 +61441,7 @@
 		"songID": 539,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58226,6 +61460,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58244,6 +61479,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58262,6 +61498,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58280,6 +61517,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58298,6 +61536,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58316,6 +61555,7 @@
 		"songID": 540,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58334,6 +61574,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58352,6 +61593,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58370,6 +61612,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58388,6 +61631,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58406,6 +61650,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58424,6 +61669,7 @@
 		"songID": 541,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58442,6 +61688,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58460,6 +61707,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58478,6 +61726,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58496,6 +61745,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58514,6 +61764,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58532,6 +61783,7 @@
 		"songID": 542,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58550,6 +61802,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58568,6 +61821,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58586,6 +61840,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58604,6 +61859,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58622,6 +61878,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58640,6 +61897,7 @@
 		"songID": 543,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58658,6 +61916,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58676,6 +61935,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58694,6 +61954,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58712,6 +61973,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58730,6 +61992,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58748,6 +62011,7 @@
 		"songID": 544,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58766,6 +62030,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58784,6 +62049,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58802,6 +62068,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58820,6 +62087,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58838,6 +62106,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58856,6 +62125,7 @@
 		"songID": 545,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58874,6 +62144,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58892,6 +62163,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58910,6 +62182,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58928,6 +62201,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58946,6 +62220,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58964,6 +62239,7 @@
 		"songID": 546,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -58982,6 +62258,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59000,6 +62277,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59018,6 +62296,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59036,6 +62315,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59054,6 +62334,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59072,6 +62353,7 @@
 		"songID": 547,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59090,6 +62372,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59108,6 +62391,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59126,6 +62410,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59144,6 +62429,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59162,6 +62448,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59180,6 +62467,7 @@
 		"songID": 548,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59198,6 +62486,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59216,6 +62505,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59234,6 +62524,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59252,6 +62543,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59270,6 +62562,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59288,6 +62581,7 @@
 		"songID": 549,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59306,6 +62600,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59324,6 +62619,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59342,6 +62638,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59360,6 +62657,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59378,6 +62676,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59396,6 +62695,7 @@
 		"songID": 550,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59414,6 +62714,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59432,6 +62733,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59450,6 +62752,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59468,6 +62771,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59486,6 +62790,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59504,6 +62809,7 @@
 		"songID": 551,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59522,6 +62828,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59540,6 +62847,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59558,6 +62866,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59576,6 +62885,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59594,6 +62904,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59612,6 +62923,7 @@
 		"songID": 552,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59630,6 +62942,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59648,6 +62961,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59666,6 +62980,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59684,6 +62999,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59702,6 +63018,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59720,6 +63037,7 @@
 		"songID": 553,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59738,6 +63056,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59756,6 +63075,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59774,6 +63094,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59792,6 +63113,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59810,6 +63132,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59828,6 +63151,7 @@
 		"songID": 554,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59846,6 +63170,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59864,6 +63189,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59882,6 +63208,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59900,6 +63227,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59918,6 +63246,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59936,6 +63265,7 @@
 		"songID": 555,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59954,6 +63284,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59972,6 +63303,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -59990,6 +63322,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60008,6 +63341,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60026,6 +63360,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60044,6 +63379,7 @@
 		"songID": 556,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60062,6 +63398,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60080,6 +63417,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60098,6 +63436,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60116,6 +63455,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60134,6 +63474,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60152,6 +63493,7 @@
 		"songID": 557,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60170,6 +63512,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60188,6 +63531,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60206,6 +63550,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60224,6 +63569,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60242,6 +63588,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60260,6 +63607,7 @@
 		"songID": 558,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60278,6 +63626,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60296,6 +63645,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60314,6 +63664,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60332,6 +63683,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60350,6 +63702,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60368,6 +63721,7 @@
 		"songID": 559,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60386,6 +63740,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60404,6 +63759,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60422,6 +63778,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60440,6 +63797,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60458,6 +63816,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60476,6 +63835,7 @@
 		"songID": 560,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60494,6 +63854,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60512,6 +63873,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60530,6 +63892,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60548,6 +63911,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60566,6 +63930,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60584,6 +63949,7 @@
 		"songID": 561,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60602,6 +63968,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60620,6 +63987,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60638,6 +64006,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60656,6 +64025,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60674,6 +64044,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60692,6 +64063,7 @@
 		"songID": 562,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60710,6 +64082,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60728,6 +64101,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60746,6 +64120,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60764,6 +64139,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60782,6 +64158,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60800,6 +64177,7 @@
 		"songID": 563,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60818,6 +64196,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60836,6 +64215,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60854,6 +64234,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60872,6 +64253,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60890,6 +64272,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60908,6 +64291,7 @@
 		"songID": 564,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60926,6 +64310,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60944,6 +64329,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60962,6 +64348,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60980,6 +64367,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -60998,6 +64386,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61016,6 +64405,7 @@
 		"songID": 565,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61034,6 +64424,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61052,6 +64443,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61070,6 +64462,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61088,6 +64481,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61106,6 +64500,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61124,6 +64519,7 @@
 		"songID": 566,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61142,6 +64538,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61160,6 +64557,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61178,6 +64576,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61196,6 +64595,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61214,6 +64614,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61232,6 +64633,7 @@
 		"songID": 567,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61250,6 +64652,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61268,6 +64671,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61286,6 +64690,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61304,6 +64709,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61322,6 +64728,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61340,6 +64747,7 @@
 		"songID": 568,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61358,6 +64766,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61376,6 +64785,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61394,6 +64804,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61412,6 +64823,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61430,6 +64842,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61448,6 +64861,7 @@
 		"songID": 569,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61466,6 +64880,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61484,6 +64899,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61502,6 +64918,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61520,6 +64937,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61538,6 +64956,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61556,6 +64975,7 @@
 		"songID": 570,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61574,6 +64994,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61592,6 +65013,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61610,6 +65032,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61628,6 +65051,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61646,6 +65070,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61664,6 +65089,7 @@
 		"songID": 571,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61682,6 +65108,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61700,6 +65127,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61718,6 +65146,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61736,6 +65165,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61754,6 +65184,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61772,6 +65203,7 @@
 		"songID": 572,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61790,6 +65222,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61808,6 +65241,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61826,6 +65260,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61844,6 +65279,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61862,6 +65298,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61880,6 +65317,7 @@
 		"songID": 573,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61898,6 +65336,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61916,6 +65355,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61934,6 +65374,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61952,6 +65393,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61970,6 +65412,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -61988,6 +65431,7 @@
 		"songID": 574,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62006,6 +65450,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62024,6 +65469,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62042,6 +65488,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62060,6 +65507,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62078,6 +65526,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62096,6 +65545,7 @@
 		"songID": 575,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62114,6 +65564,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62132,6 +65583,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62150,6 +65602,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62168,6 +65621,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62186,6 +65640,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62204,6 +65659,7 @@
 		"songID": 576,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62222,6 +65678,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62240,6 +65697,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62258,6 +65716,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62276,6 +65735,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62294,6 +65754,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62312,6 +65773,7 @@
 		"songID": 577,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62330,6 +65792,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62348,6 +65811,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62366,6 +65830,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62384,6 +65849,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62402,6 +65868,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62420,6 +65887,7 @@
 		"songID": 578,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62438,6 +65906,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62456,6 +65925,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62474,6 +65944,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62492,6 +65963,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62510,6 +65982,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62528,6 +66001,7 @@
 		"songID": 579,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62546,6 +66020,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62564,6 +66039,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62582,6 +66058,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62600,6 +66077,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62618,6 +66096,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62636,6 +66115,7 @@
 		"songID": 580,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62654,6 +66134,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62672,6 +66153,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62690,6 +66172,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62708,6 +66191,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62726,6 +66210,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62744,6 +66229,7 @@
 		"songID": 581,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62762,6 +66248,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62780,6 +66267,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62798,6 +66286,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62816,6 +66305,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62834,6 +66324,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62852,6 +66343,7 @@
 		"songID": 582,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62870,6 +66362,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62888,6 +66381,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62906,6 +66400,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62924,6 +66419,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62942,6 +66438,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62960,6 +66457,7 @@
 		"songID": 583,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62978,6 +66476,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -62996,6 +66495,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63014,6 +66514,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63032,6 +66533,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63050,6 +66552,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63068,6 +66571,7 @@
 		"songID": 584,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63086,6 +66590,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63104,6 +66609,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63122,6 +66628,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63140,6 +66647,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63158,6 +66666,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63176,6 +66685,7 @@
 		"songID": 585,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63302,6 +66812,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63320,6 +66831,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63338,6 +66850,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63356,6 +66869,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63374,6 +66888,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63392,6 +66907,7 @@
 		"songID": 587,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63410,6 +66926,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63428,6 +66945,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63446,6 +66964,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63464,6 +66983,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63482,6 +67002,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63500,6 +67021,7 @@
 		"songID": 588,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63518,6 +67040,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63536,6 +67059,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63554,6 +67078,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63572,6 +67097,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63590,6 +67116,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63608,6 +67135,7 @@
 		"songID": 589,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63626,6 +67154,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63644,6 +67173,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63662,6 +67192,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63680,6 +67211,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63698,6 +67230,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63716,6 +67249,7 @@
 		"songID": 590,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63734,6 +67268,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63752,6 +67287,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63770,6 +67306,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63788,6 +67325,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63806,6 +67344,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63824,6 +67363,7 @@
 		"songID": 591,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63842,6 +67382,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63860,6 +67401,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63878,6 +67420,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63896,6 +67439,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63914,6 +67458,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63932,6 +67477,7 @@
 		"songID": 592,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63950,6 +67496,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63968,6 +67515,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -63986,6 +67534,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64004,6 +67553,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64022,6 +67572,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64040,6 +67591,7 @@
 		"songID": 593,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64058,6 +67610,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64076,6 +67629,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64094,6 +67648,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64112,6 +67667,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64130,6 +67686,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64148,6 +67705,7 @@
 		"songID": 594,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64166,6 +67724,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64184,6 +67743,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64202,6 +67762,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64220,6 +67781,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64238,6 +67800,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64256,6 +67819,7 @@
 		"songID": 595,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64274,6 +67838,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64292,6 +67857,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64310,6 +67876,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64328,6 +67895,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64346,6 +67914,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64364,6 +67933,7 @@
 		"songID": 596,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64382,6 +67952,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64400,6 +67971,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64418,6 +67990,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64436,6 +68009,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64454,6 +68028,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64472,6 +68047,7 @@
 		"songID": 597,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64490,6 +68066,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64508,6 +68085,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64526,6 +68104,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64544,6 +68123,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64562,6 +68142,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64580,6 +68161,7 @@
 		"songID": 598,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64598,6 +68180,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64616,6 +68199,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64634,6 +68218,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64652,6 +68237,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64670,6 +68256,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64688,6 +68275,7 @@
 		"songID": 599,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64706,6 +68294,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64724,6 +68313,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64742,6 +68332,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64760,6 +68351,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64778,6 +68370,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64796,6 +68389,7 @@
 		"songID": 600,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64814,6 +68408,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64832,6 +68427,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64850,6 +68446,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64868,6 +68465,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64886,6 +68484,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64904,6 +68503,7 @@
 		"songID": 601,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64922,6 +68522,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64940,6 +68541,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64958,6 +68560,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64976,6 +68579,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -64994,6 +68598,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65012,6 +68617,7 @@
 		"songID": 602,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65030,6 +68636,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65048,6 +68655,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65066,6 +68674,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65084,6 +68693,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65102,6 +68712,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65120,6 +68731,7 @@
 		"songID": 603,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65138,6 +68750,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65156,6 +68769,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65174,6 +68788,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65192,6 +68807,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65210,6 +68826,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65228,6 +68845,7 @@
 		"songID": 604,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65246,6 +68864,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65264,6 +68883,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65282,6 +68902,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65300,6 +68921,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65318,6 +68940,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65336,6 +68959,7 @@
 		"songID": 605,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65354,6 +68978,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65372,6 +68997,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65390,6 +69016,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65408,6 +69035,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65426,6 +69054,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65444,6 +69073,7 @@
 		"songID": 606,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65462,6 +69092,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65480,6 +69111,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65498,6 +69130,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65516,6 +69149,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65534,6 +69168,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65552,6 +69187,7 @@
 		"songID": 607,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65570,6 +69206,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65588,6 +69225,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65606,6 +69244,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65624,6 +69263,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65642,6 +69282,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65660,6 +69301,7 @@
 		"songID": 608,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65678,6 +69320,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65696,6 +69339,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65714,6 +69358,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65732,6 +69377,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65750,6 +69396,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65768,6 +69415,7 @@
 		"songID": 609,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65786,6 +69434,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65804,6 +69453,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65822,6 +69472,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65840,6 +69491,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65858,6 +69510,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -65876,6 +69529,7 @@
 		"songID": 610,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66002,6 +69656,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66020,6 +69675,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66038,6 +69694,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66056,6 +69713,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66074,6 +69732,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66092,6 +69751,7 @@
 		"songID": 612,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66110,6 +69770,7 @@
 		"songID": 613,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66128,6 +69789,7 @@
 		"songID": 613,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66146,6 +69808,7 @@
 		"songID": 613,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66164,6 +69827,7 @@
 		"songID": 613,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66182,6 +69846,7 @@
 		"songID": 613,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66200,6 +69865,7 @@
 		"songID": 613,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66218,6 +69884,7 @@
 		"songID": 614,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66236,6 +69903,7 @@
 		"songID": 614,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66254,6 +69922,7 @@
 		"songID": 614,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66272,6 +69941,7 @@
 		"songID": 614,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66290,6 +69960,7 @@
 		"songID": 614,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66308,6 +69979,7 @@
 		"songID": 614,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66326,6 +69998,7 @@
 		"songID": 615,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66344,6 +70017,7 @@
 		"songID": 615,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66362,6 +70036,7 @@
 		"songID": 615,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66380,6 +70055,7 @@
 		"songID": 615,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66398,6 +70074,7 @@
 		"songID": 615,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66416,6 +70093,7 @@
 		"songID": 615,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66434,6 +70112,7 @@
 		"songID": 616,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66452,6 +70131,7 @@
 		"songID": 616,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66470,6 +70150,7 @@
 		"songID": 616,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66488,6 +70169,7 @@
 		"songID": 616,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66506,6 +70188,7 @@
 		"songID": 616,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66524,6 +70207,7 @@
 		"songID": 616,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66542,6 +70226,7 @@
 		"songID": 617,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66560,6 +70245,7 @@
 		"songID": 617,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66578,6 +70264,7 @@
 		"songID": 617,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66596,6 +70283,7 @@
 		"songID": 617,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66614,6 +70302,7 @@
 		"songID": 617,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66632,6 +70321,7 @@
 		"songID": 617,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66650,6 +70340,7 @@
 		"songID": 618,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66668,6 +70359,7 @@
 		"songID": 618,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66686,6 +70378,7 @@
 		"songID": 618,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66704,6 +70397,7 @@
 		"songID": 618,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66722,6 +70416,7 @@
 		"songID": 618,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66740,6 +70435,7 @@
 		"songID": 618,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66758,6 +70454,7 @@
 		"songID": 619,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66776,6 +70473,7 @@
 		"songID": 619,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66794,6 +70492,7 @@
 		"songID": 619,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66812,6 +70511,7 @@
 		"songID": 619,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66830,6 +70530,7 @@
 		"songID": 619,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66848,6 +70549,7 @@
 		"songID": 619,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66866,6 +70568,7 @@
 		"songID": 620,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66884,6 +70587,7 @@
 		"songID": 620,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66902,6 +70606,7 @@
 		"songID": 620,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66920,6 +70625,7 @@
 		"songID": 620,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66938,6 +70644,7 @@
 		"songID": 620,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66956,6 +70663,7 @@
 		"songID": 620,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66974,6 +70682,7 @@
 		"songID": 621,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -66992,6 +70701,7 @@
 		"songID": 621,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67010,6 +70720,7 @@
 		"songID": 621,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67028,6 +70739,7 @@
 		"songID": 621,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67046,6 +70758,7 @@
 		"songID": 621,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67064,6 +70777,7 @@
 		"songID": 621,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67082,6 +70796,7 @@
 		"songID": 622,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67100,6 +70815,7 @@
 		"songID": 622,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67118,6 +70834,7 @@
 		"songID": 622,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67136,6 +70853,7 @@
 		"songID": 622,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67154,6 +70872,7 @@
 		"songID": 622,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67172,6 +70891,7 @@
 		"songID": 622,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67190,6 +70910,7 @@
 		"songID": 623,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67208,6 +70929,7 @@
 		"songID": 623,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67226,6 +70948,7 @@
 		"songID": 623,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67244,6 +70967,7 @@
 		"songID": 623,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67262,6 +70986,7 @@
 		"songID": 623,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67280,6 +71005,7 @@
 		"songID": 623,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67298,6 +71024,7 @@
 		"songID": 624,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67316,6 +71043,7 @@
 		"songID": 624,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67334,6 +71062,7 @@
 		"songID": 624,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67352,6 +71081,7 @@
 		"songID": 624,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67370,6 +71100,7 @@
 		"songID": 624,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67388,6 +71119,7 @@
 		"songID": 624,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67406,6 +71138,7 @@
 		"songID": 625,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67424,6 +71157,7 @@
 		"songID": 625,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67442,6 +71176,7 @@
 		"songID": 625,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67460,6 +71195,7 @@
 		"songID": 625,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67478,6 +71214,7 @@
 		"songID": 625,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67496,6 +71233,7 @@
 		"songID": 625,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67514,6 +71252,7 @@
 		"songID": 626,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67532,6 +71271,7 @@
 		"songID": 626,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67550,6 +71290,7 @@
 		"songID": 626,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67568,6 +71309,7 @@
 		"songID": 626,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67586,6 +71328,7 @@
 		"songID": 626,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67604,6 +71347,7 @@
 		"songID": 626,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67622,6 +71366,7 @@
 		"songID": 627,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67640,6 +71385,7 @@
 		"songID": 627,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67658,6 +71404,7 @@
 		"songID": 627,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67676,6 +71423,7 @@
 		"songID": 627,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67694,6 +71442,7 @@
 		"songID": 627,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67712,6 +71461,7 @@
 		"songID": 627,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67730,6 +71480,7 @@
 		"songID": 628,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67748,6 +71499,7 @@
 		"songID": 628,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67766,6 +71518,7 @@
 		"songID": 628,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67784,6 +71537,7 @@
 		"songID": 628,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67802,6 +71556,7 @@
 		"songID": 628,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67820,6 +71575,7 @@
 		"songID": 628,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67838,6 +71594,7 @@
 		"songID": 629,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67856,6 +71613,7 @@
 		"songID": 629,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67874,6 +71632,7 @@
 		"songID": 629,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67892,6 +71651,7 @@
 		"songID": 629,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67910,6 +71670,7 @@
 		"songID": 629,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67928,6 +71689,7 @@
 		"songID": 629,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67946,6 +71708,7 @@
 		"songID": 630,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67964,6 +71727,7 @@
 		"songID": 630,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -67982,6 +71746,7 @@
 		"songID": 630,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68000,6 +71765,7 @@
 		"songID": 630,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68018,6 +71784,7 @@
 		"songID": 630,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68036,6 +71803,7 @@
 		"songID": 630,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68054,6 +71822,7 @@
 		"songID": 631,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68072,6 +71841,7 @@
 		"songID": 631,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68090,6 +71860,7 @@
 		"songID": 631,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68108,6 +71879,7 @@
 		"songID": 631,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68126,6 +71898,7 @@
 		"songID": 631,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68144,6 +71917,7 @@
 		"songID": 631,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68162,6 +71936,7 @@
 		"songID": 632,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68180,6 +71955,7 @@
 		"songID": 632,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68198,6 +71974,7 @@
 		"songID": 632,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68216,6 +71993,7 @@
 		"songID": 632,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68234,6 +72012,7 @@
 		"songID": 632,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68252,6 +72031,7 @@
 		"songID": 632,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68270,6 +72050,7 @@
 		"songID": 633,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68288,6 +72069,7 @@
 		"songID": 633,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68306,6 +72088,7 @@
 		"songID": 633,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68324,6 +72107,7 @@
 		"songID": 633,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68342,6 +72126,7 @@
 		"songID": 633,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68360,6 +72145,7 @@
 		"songID": 633,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68378,6 +72164,7 @@
 		"songID": 634,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68396,6 +72183,7 @@
 		"songID": 634,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68414,6 +72202,7 @@
 		"songID": 634,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68432,6 +72221,7 @@
 		"songID": 634,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68450,6 +72240,7 @@
 		"songID": 634,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68468,6 +72259,7 @@
 		"songID": 634,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68486,6 +72278,7 @@
 		"songID": 635,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68504,6 +72297,7 @@
 		"songID": 635,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68522,6 +72316,7 @@
 		"songID": 635,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68540,6 +72335,7 @@
 		"songID": 635,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68558,6 +72354,7 @@
 		"songID": 635,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68576,6 +72373,7 @@
 		"songID": 635,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68594,6 +72392,7 @@
 		"songID": 636,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68612,6 +72411,7 @@
 		"songID": 636,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68630,6 +72430,7 @@
 		"songID": 636,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68648,6 +72449,7 @@
 		"songID": 636,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68666,6 +72468,7 @@
 		"songID": 636,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68684,6 +72487,7 @@
 		"songID": 636,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68702,6 +72506,7 @@
 		"songID": 637,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68720,6 +72525,7 @@
 		"songID": 637,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68738,6 +72544,7 @@
 		"songID": 637,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68756,6 +72563,7 @@
 		"songID": 637,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68774,6 +72582,7 @@
 		"songID": 637,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68792,6 +72601,7 @@
 		"songID": 637,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68810,6 +72620,7 @@
 		"songID": 638,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68828,6 +72639,7 @@
 		"songID": 638,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68846,6 +72658,7 @@
 		"songID": 638,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68864,6 +72677,7 @@
 		"songID": 638,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68882,6 +72696,7 @@
 		"songID": 638,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68900,6 +72715,7 @@
 		"songID": 638,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68918,6 +72734,7 @@
 		"songID": 639,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68936,6 +72753,7 @@
 		"songID": 639,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68954,6 +72772,7 @@
 		"songID": 639,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68972,6 +72791,7 @@
 		"songID": 639,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -68990,6 +72810,7 @@
 		"songID": 639,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69008,6 +72829,7 @@
 		"songID": 639,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69026,6 +72848,7 @@
 		"songID": 640,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69044,6 +72867,7 @@
 		"songID": 640,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69062,6 +72886,7 @@
 		"songID": 640,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69080,6 +72905,7 @@
 		"songID": 640,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69098,6 +72924,7 @@
 		"songID": 640,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69116,6 +72943,7 @@
 		"songID": 640,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69134,6 +72962,7 @@
 		"songID": 641,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69152,6 +72981,7 @@
 		"songID": 641,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69170,6 +73000,7 @@
 		"songID": 641,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69188,6 +73019,7 @@
 		"songID": 641,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69206,6 +73038,7 @@
 		"songID": 641,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69224,6 +73057,7 @@
 		"songID": 641,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69242,6 +73076,7 @@
 		"songID": 642,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69260,6 +73095,7 @@
 		"songID": 642,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69278,6 +73114,7 @@
 		"songID": 642,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69296,6 +73133,7 @@
 		"songID": 642,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69314,6 +73152,7 @@
 		"songID": 642,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69332,6 +73171,7 @@
 		"songID": 642,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69350,6 +73190,7 @@
 		"songID": 643,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69368,6 +73209,7 @@
 		"songID": 643,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69386,6 +73228,7 @@
 		"songID": 643,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69404,6 +73247,7 @@
 		"songID": 643,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69422,6 +73266,7 @@
 		"songID": 643,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69440,6 +73285,7 @@
 		"songID": 643,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69458,6 +73304,7 @@
 		"songID": 644,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69476,6 +73323,7 @@
 		"songID": 644,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69494,6 +73342,7 @@
 		"songID": 644,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69512,6 +73361,7 @@
 		"songID": 644,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69530,6 +73380,7 @@
 		"songID": 644,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69548,6 +73399,7 @@
 		"songID": 644,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69566,6 +73418,7 @@
 		"songID": 645,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69584,6 +73437,7 @@
 		"songID": 645,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69602,6 +73456,7 @@
 		"songID": 645,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69620,6 +73475,7 @@
 		"songID": 645,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69638,6 +73494,7 @@
 		"songID": 645,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69656,6 +73513,7 @@
 		"songID": 645,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69674,6 +73532,7 @@
 		"songID": 646,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69692,6 +73551,7 @@
 		"songID": 646,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69710,6 +73570,7 @@
 		"songID": 646,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69728,6 +73589,7 @@
 		"songID": 646,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69746,6 +73608,7 @@
 		"songID": 646,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69764,6 +73627,7 @@
 		"songID": 646,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69782,6 +73646,7 @@
 		"songID": 647,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69800,6 +73665,7 @@
 		"songID": 647,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69818,6 +73684,7 @@
 		"songID": 647,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69836,6 +73703,7 @@
 		"songID": 647,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69854,6 +73722,7 @@
 		"songID": 647,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69872,6 +73741,7 @@
 		"songID": 647,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69890,6 +73760,7 @@
 		"songID": 648,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69908,6 +73779,7 @@
 		"songID": 648,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69926,6 +73798,7 @@
 		"songID": 648,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69944,6 +73817,7 @@
 		"songID": 648,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69962,6 +73836,7 @@
 		"songID": 648,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69980,6 +73855,7 @@
 		"songID": 648,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -69998,6 +73874,7 @@
 		"songID": 649,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70016,6 +73893,7 @@
 		"songID": 649,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70034,6 +73912,7 @@
 		"songID": 649,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70052,6 +73931,7 @@
 		"songID": 649,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70070,6 +73950,7 @@
 		"songID": 649,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70088,6 +73969,7 @@
 		"songID": 649,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70106,6 +73988,7 @@
 		"songID": 650,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70124,6 +74007,7 @@
 		"songID": 650,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70142,6 +74026,7 @@
 		"songID": 650,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70160,6 +74045,7 @@
 		"songID": 650,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70178,6 +74064,7 @@
 		"songID": 650,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70196,6 +74083,7 @@
 		"songID": 650,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70214,6 +74102,7 @@
 		"songID": 651,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70232,6 +74121,7 @@
 		"songID": 651,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70250,6 +74140,7 @@
 		"songID": 651,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70268,6 +74159,7 @@
 		"songID": 651,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70286,6 +74178,7 @@
 		"songID": 651,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70304,6 +74197,7 @@
 		"songID": 651,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70322,6 +74216,7 @@
 		"songID": 652,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70340,6 +74235,7 @@
 		"songID": 652,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70358,6 +74254,7 @@
 		"songID": 652,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70376,6 +74273,7 @@
 		"songID": 652,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70394,6 +74292,7 @@
 		"songID": 652,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70412,6 +74311,7 @@
 		"songID": 652,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70430,6 +74330,7 @@
 		"songID": 653,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70448,6 +74349,7 @@
 		"songID": 653,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70466,6 +74368,7 @@
 		"songID": 653,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70484,6 +74387,7 @@
 		"songID": 653,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70502,6 +74406,7 @@
 		"songID": 653,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70520,6 +74425,7 @@
 		"songID": 653,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70538,6 +74444,7 @@
 		"songID": 654,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70556,6 +74463,7 @@
 		"songID": 654,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70574,6 +74482,7 @@
 		"songID": 654,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70592,6 +74501,7 @@
 		"songID": 654,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70610,6 +74520,7 @@
 		"songID": 654,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70628,6 +74539,7 @@
 		"songID": 654,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70646,6 +74558,7 @@
 		"songID": 655,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70664,6 +74577,7 @@
 		"songID": 655,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70682,6 +74596,7 @@
 		"songID": 655,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70700,6 +74615,7 @@
 		"songID": 655,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70718,6 +74634,7 @@
 		"songID": 655,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70736,6 +74653,7 @@
 		"songID": 655,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70754,6 +74672,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70772,6 +74691,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70790,6 +74710,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70808,6 +74729,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70826,6 +74748,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70844,6 +74767,7 @@
 		"songID": 656,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70862,6 +74786,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70880,6 +74805,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70898,6 +74824,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70916,6 +74843,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70934,6 +74862,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70952,6 +74881,7 @@
 		"songID": 657,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70970,6 +74900,7 @@
 		"songID": 658,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -70988,6 +74919,7 @@
 		"songID": 658,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71006,6 +74938,7 @@
 		"songID": 658,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71024,6 +74957,7 @@
 		"songID": 658,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71042,6 +74976,7 @@
 		"songID": 658,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71060,6 +74995,7 @@
 		"songID": 658,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71078,6 +75014,7 @@
 		"songID": 659,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71096,6 +75033,7 @@
 		"songID": 659,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71114,6 +75052,7 @@
 		"songID": 659,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71132,6 +75071,7 @@
 		"songID": 659,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71150,6 +75090,7 @@
 		"songID": 659,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71168,6 +75109,7 @@
 		"songID": 659,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71186,6 +75128,7 @@
 		"songID": 660,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71204,6 +75147,7 @@
 		"songID": 660,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71222,6 +75166,7 @@
 		"songID": 660,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71240,6 +75185,7 @@
 		"songID": 660,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71258,6 +75204,7 @@
 		"songID": 660,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71276,6 +75223,7 @@
 		"songID": 660,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71294,6 +75242,7 @@
 		"songID": 661,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71312,6 +75261,7 @@
 		"songID": 661,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71330,6 +75280,7 @@
 		"songID": 661,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71348,6 +75299,7 @@
 		"songID": 661,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71366,6 +75318,7 @@
 		"songID": 661,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71384,6 +75337,7 @@
 		"songID": 661,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71402,6 +75356,7 @@
 		"songID": 662,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71420,6 +75375,7 @@
 		"songID": 662,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71438,6 +75394,7 @@
 		"songID": 662,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71456,6 +75413,7 @@
 		"songID": 662,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71474,6 +75432,7 @@
 		"songID": 662,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71492,6 +75451,7 @@
 		"songID": 662,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71510,6 +75470,7 @@
 		"songID": 663,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71528,6 +75489,7 @@
 		"songID": 663,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71546,6 +75508,7 @@
 		"songID": 663,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71564,6 +75527,7 @@
 		"songID": 663,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71582,6 +75546,7 @@
 		"songID": 663,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71600,6 +75565,7 @@
 		"songID": 663,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71618,6 +75584,7 @@
 		"songID": 664,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71636,6 +75603,7 @@
 		"songID": 664,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71654,6 +75622,7 @@
 		"songID": 664,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71672,6 +75641,7 @@
 		"songID": 664,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71690,6 +75660,7 @@
 		"songID": 664,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71708,6 +75679,7 @@
 		"songID": 664,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71726,6 +75698,7 @@
 		"songID": 665,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71744,6 +75717,7 @@
 		"songID": 665,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71762,6 +75736,7 @@
 		"songID": 665,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71780,6 +75755,7 @@
 		"songID": 665,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71798,6 +75774,7 @@
 		"songID": 665,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71816,6 +75793,7 @@
 		"songID": 665,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71834,6 +75812,7 @@
 		"songID": 666,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71852,6 +75831,7 @@
 		"songID": 666,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71870,6 +75850,7 @@
 		"songID": 666,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71888,6 +75869,7 @@
 		"songID": 666,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71906,6 +75888,7 @@
 		"songID": 666,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71924,6 +75907,7 @@
 		"songID": 666,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71942,6 +75926,7 @@
 		"songID": 667,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71960,6 +75945,7 @@
 		"songID": 667,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71978,6 +75964,7 @@
 		"songID": 667,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -71996,6 +75983,7 @@
 		"songID": 667,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72014,6 +76002,7 @@
 		"songID": 667,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72032,6 +76021,7 @@
 		"songID": 667,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72050,6 +76040,7 @@
 		"songID": 668,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72068,6 +76059,7 @@
 		"songID": 668,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72086,6 +76078,7 @@
 		"songID": 668,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72104,6 +76097,7 @@
 		"songID": 668,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72122,6 +76116,7 @@
 		"songID": 668,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72140,6 +76135,7 @@
 		"songID": 668,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72158,6 +76154,7 @@
 		"songID": 669,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72176,6 +76173,7 @@
 		"songID": 669,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72194,6 +76192,7 @@
 		"songID": 669,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72212,6 +76211,7 @@
 		"songID": 669,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72230,6 +76230,7 @@
 		"songID": 669,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72248,6 +76249,7 @@
 		"songID": 669,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72266,6 +76268,7 @@
 		"songID": 670,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72284,6 +76287,7 @@
 		"songID": 670,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72302,6 +76306,7 @@
 		"songID": 670,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72320,6 +76325,7 @@
 		"songID": 670,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72338,6 +76344,7 @@
 		"songID": 670,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72356,6 +76363,7 @@
 		"songID": 670,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72374,6 +76382,7 @@
 		"songID": 671,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72392,6 +76401,7 @@
 		"songID": 671,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72410,6 +76420,7 @@
 		"songID": 671,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72428,6 +76439,7 @@
 		"songID": 671,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72446,6 +76458,7 @@
 		"songID": 671,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72464,6 +76477,7 @@
 		"songID": 671,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72482,6 +76496,7 @@
 		"songID": 672,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72500,6 +76515,7 @@
 		"songID": 672,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72518,6 +76534,7 @@
 		"songID": 672,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72536,6 +76553,7 @@
 		"songID": 672,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72554,6 +76572,7 @@
 		"songID": 672,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72572,6 +76591,7 @@
 		"songID": 672,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72590,6 +76610,7 @@
 		"songID": 673,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72608,6 +76629,7 @@
 		"songID": 673,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72626,6 +76648,7 @@
 		"songID": 673,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72644,6 +76667,7 @@
 		"songID": 673,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72662,6 +76686,7 @@
 		"songID": 673,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72680,6 +76705,7 @@
 		"songID": 673,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72698,6 +76724,7 @@
 		"songID": 674,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72716,6 +76743,7 @@
 		"songID": 674,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72734,6 +76762,7 @@
 		"songID": 674,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72752,6 +76781,7 @@
 		"songID": 674,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72770,6 +76800,7 @@
 		"songID": 674,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72788,6 +76819,7 @@
 		"songID": 674,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72806,6 +76838,7 @@
 		"songID": 675,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72824,6 +76857,7 @@
 		"songID": 675,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72842,6 +76876,7 @@
 		"songID": 675,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72860,6 +76895,7 @@
 		"songID": 675,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72878,6 +76914,7 @@
 		"songID": 675,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72896,6 +76933,7 @@
 		"songID": 675,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72914,6 +76952,7 @@
 		"songID": 676,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72932,6 +76971,7 @@
 		"songID": 676,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72950,6 +76990,7 @@
 		"songID": 676,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72968,6 +77009,7 @@
 		"songID": 676,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -72986,6 +77028,7 @@
 		"songID": 676,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73004,6 +77047,7 @@
 		"songID": 676,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73022,6 +77066,7 @@
 		"songID": 677,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73040,6 +77085,7 @@
 		"songID": 677,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73058,6 +77104,7 @@
 		"songID": 677,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73076,6 +77123,7 @@
 		"songID": 677,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73094,6 +77142,7 @@
 		"songID": 677,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73112,6 +77161,7 @@
 		"songID": 677,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73130,6 +77180,7 @@
 		"songID": 678,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73148,6 +77199,7 @@
 		"songID": 678,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73166,6 +77218,7 @@
 		"songID": 678,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73184,6 +77237,7 @@
 		"songID": 678,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73202,6 +77256,7 @@
 		"songID": 678,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73220,6 +77275,7 @@
 		"songID": 678,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73238,6 +77294,7 @@
 		"songID": 679,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73256,6 +77313,7 @@
 		"songID": 679,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73274,6 +77332,7 @@
 		"songID": 679,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73292,6 +77351,7 @@
 		"songID": 679,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73310,6 +77370,7 @@
 		"songID": 679,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73328,6 +77389,7 @@
 		"songID": 679,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73346,6 +77408,7 @@
 		"songID": 680,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73364,6 +77427,7 @@
 		"songID": 680,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73382,6 +77446,7 @@
 		"songID": 680,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73400,6 +77465,7 @@
 		"songID": 680,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73418,6 +77484,7 @@
 		"songID": 680,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73436,6 +77503,7 @@
 		"songID": 680,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73454,6 +77522,7 @@
 		"songID": 681,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73472,6 +77541,7 @@
 		"songID": 681,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73490,6 +77560,7 @@
 		"songID": 681,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73508,6 +77579,7 @@
 		"songID": 681,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73526,6 +77598,7 @@
 		"songID": 681,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73544,6 +77617,7 @@
 		"songID": 681,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73562,6 +77636,7 @@
 		"songID": 682,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73580,6 +77655,7 @@
 		"songID": 682,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73598,6 +77674,7 @@
 		"songID": 682,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73616,6 +77693,7 @@
 		"songID": 682,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73634,6 +77712,7 @@
 		"songID": 682,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73652,6 +77731,7 @@
 		"songID": 682,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73670,6 +77750,7 @@
 		"songID": 683,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73688,6 +77769,7 @@
 		"songID": 683,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73706,6 +77788,7 @@
 		"songID": 683,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73724,6 +77807,7 @@
 		"songID": 683,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73742,6 +77826,7 @@
 		"songID": 683,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73760,6 +77845,7 @@
 		"songID": 683,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73778,6 +77864,7 @@
 		"songID": 684,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73796,6 +77883,7 @@
 		"songID": 684,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73814,6 +77902,7 @@
 		"songID": 684,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73832,6 +77921,7 @@
 		"songID": 684,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73850,6 +77940,7 @@
 		"songID": 684,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73868,6 +77959,7 @@
 		"songID": 684,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73886,6 +77978,7 @@
 		"songID": 685,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73904,6 +77997,7 @@
 		"songID": 685,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73922,6 +78016,7 @@
 		"songID": 685,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73940,6 +78035,7 @@
 		"songID": 685,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73958,6 +78054,7 @@
 		"songID": 685,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73976,6 +78073,7 @@
 		"songID": 685,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -73994,6 +78092,7 @@
 		"songID": 686,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74012,6 +78111,7 @@
 		"songID": 686,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74030,6 +78130,7 @@
 		"songID": 686,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74048,6 +78149,7 @@
 		"songID": 686,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74066,6 +78168,7 @@
 		"songID": 686,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74084,6 +78187,7 @@
 		"songID": 686,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74102,6 +78206,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74120,6 +78225,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74138,6 +78244,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74156,6 +78263,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74174,6 +78282,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74192,6 +78301,7 @@
 		"songID": 687,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74210,6 +78320,7 @@
 		"songID": 688,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74228,6 +78339,7 @@
 		"songID": 688,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74246,6 +78358,7 @@
 		"songID": 688,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74264,6 +78377,7 @@
 		"songID": 688,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74282,6 +78396,7 @@
 		"songID": 688,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74300,6 +78415,7 @@
 		"songID": 688,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74318,6 +78434,7 @@
 		"songID": 689,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74336,6 +78453,7 @@
 		"songID": 689,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74354,6 +78472,7 @@
 		"songID": 689,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74372,6 +78491,7 @@
 		"songID": 689,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74390,6 +78510,7 @@
 		"songID": 689,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74408,6 +78529,7 @@
 		"songID": 689,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74426,6 +78548,7 @@
 		"songID": 690,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74444,6 +78567,7 @@
 		"songID": 690,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74462,6 +78586,7 @@
 		"songID": 690,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74480,6 +78605,7 @@
 		"songID": 690,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74498,6 +78624,7 @@
 		"songID": 690,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74516,6 +78643,7 @@
 		"songID": 690,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74534,6 +78662,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74552,6 +78681,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74570,6 +78700,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74588,6 +78719,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74606,6 +78738,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74624,6 +78757,7 @@
 		"songID": 691,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74642,6 +78776,7 @@
 		"songID": 692,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74660,6 +78795,7 @@
 		"songID": 692,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74678,6 +78814,7 @@
 		"songID": 692,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74696,6 +78833,7 @@
 		"songID": 692,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74714,6 +78852,7 @@
 		"songID": 692,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74732,6 +78871,7 @@
 		"songID": 692,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74750,6 +78890,7 @@
 		"songID": 693,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74768,6 +78909,7 @@
 		"songID": 693,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74786,6 +78928,7 @@
 		"songID": 693,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74804,6 +78947,7 @@
 		"songID": 693,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74822,6 +78966,7 @@
 		"songID": 693,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74840,6 +78985,7 @@
 		"songID": 693,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74858,6 +79004,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74876,6 +79023,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74894,6 +79042,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74912,6 +79061,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74930,6 +79080,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74948,6 +79099,7 @@
 		"songID": 694,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74966,6 +79118,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -74984,6 +79137,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75002,6 +79156,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75020,6 +79175,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75038,6 +79194,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75056,6 +79213,7 @@
 		"songID": 695,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75074,6 +79232,7 @@
 		"songID": 696,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75092,6 +79251,7 @@
 		"songID": 696,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75110,6 +79270,7 @@
 		"songID": 696,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75128,6 +79289,7 @@
 		"songID": 696,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75146,6 +79308,7 @@
 		"songID": 696,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75164,6 +79327,7 @@
 		"songID": 696,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75182,6 +79346,7 @@
 		"songID": 697,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75200,6 +79365,7 @@
 		"songID": 697,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75218,6 +79384,7 @@
 		"songID": 697,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75236,6 +79403,7 @@
 		"songID": 697,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75254,6 +79422,7 @@
 		"songID": 697,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75272,6 +79441,7 @@
 		"songID": 697,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75290,6 +79460,7 @@
 		"songID": 698,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75308,6 +79479,7 @@
 		"songID": 698,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75326,6 +79498,7 @@
 		"songID": 698,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75344,6 +79517,7 @@
 		"songID": 698,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75362,6 +79536,7 @@
 		"songID": 698,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75380,6 +79555,7 @@
 		"songID": 698,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75398,6 +79574,7 @@
 		"songID": 699,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75416,6 +79593,7 @@
 		"songID": 699,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75434,6 +79612,7 @@
 		"songID": 699,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75452,6 +79631,7 @@
 		"songID": 699,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75470,6 +79650,7 @@
 		"songID": 699,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75488,6 +79669,7 @@
 		"songID": 699,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75506,6 +79688,7 @@
 		"songID": 700,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75524,6 +79707,7 @@
 		"songID": 700,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75542,6 +79726,7 @@
 		"songID": 700,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75560,6 +79745,7 @@
 		"songID": 700,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75578,6 +79764,7 @@
 		"songID": 700,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75596,6 +79783,7 @@
 		"songID": 700,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75614,6 +79802,7 @@
 		"songID": 701,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75632,6 +79821,7 @@
 		"songID": 701,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75650,6 +79840,7 @@
 		"songID": 701,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75668,6 +79859,7 @@
 		"songID": 701,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75686,6 +79878,7 @@
 		"songID": 701,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75704,6 +79897,7 @@
 		"songID": 701,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75722,6 +79916,7 @@
 		"songID": 702,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75740,6 +79935,7 @@
 		"songID": 702,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75758,6 +79954,7 @@
 		"songID": 702,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75776,6 +79973,7 @@
 		"songID": 702,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75794,6 +79992,7 @@
 		"songID": 702,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75812,6 +80011,7 @@
 		"songID": 702,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75830,6 +80030,7 @@
 		"songID": 703,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75848,6 +80049,7 @@
 		"songID": 703,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75866,6 +80068,7 @@
 		"songID": 703,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75884,6 +80087,7 @@
 		"songID": 703,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75902,6 +80106,7 @@
 		"songID": 703,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75920,6 +80125,7 @@
 		"songID": 703,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75938,6 +80144,7 @@
 		"songID": 704,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75956,6 +80163,7 @@
 		"songID": 704,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75974,6 +80182,7 @@
 		"songID": 704,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -75992,6 +80201,7 @@
 		"songID": 704,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76010,6 +80220,7 @@
 		"songID": 704,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76028,6 +80239,7 @@
 		"songID": 704,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76046,6 +80258,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76064,6 +80277,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76082,6 +80296,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76100,6 +80315,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76118,6 +80334,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76136,6 +80353,7 @@
 		"songID": 705,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76154,6 +80372,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76172,6 +80391,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76190,6 +80410,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76208,6 +80429,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76226,6 +80448,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76244,6 +80467,7 @@
 		"songID": 706,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76262,6 +80486,7 @@
 		"songID": 707,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76280,6 +80505,7 @@
 		"songID": 707,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76298,6 +80524,7 @@
 		"songID": 707,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76316,6 +80543,7 @@
 		"songID": 707,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76334,6 +80562,7 @@
 		"songID": 707,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76352,6 +80581,7 @@
 		"songID": 707,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76370,6 +80600,7 @@
 		"songID": 708,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76388,6 +80619,7 @@
 		"songID": 708,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76406,6 +80638,7 @@
 		"songID": 708,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76424,6 +80657,7 @@
 		"songID": 708,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76442,6 +80676,7 @@
 		"songID": 708,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76460,6 +80695,7 @@
 		"songID": 708,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76478,6 +80714,7 @@
 		"songID": 709,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76496,6 +80733,7 @@
 		"songID": 709,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76514,6 +80752,7 @@
 		"songID": 709,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76532,6 +80771,7 @@
 		"songID": 709,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76550,6 +80790,7 @@
 		"songID": 709,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76568,6 +80809,7 @@
 		"songID": 709,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76586,6 +80828,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76604,6 +80847,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76622,6 +80866,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76640,6 +80885,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76658,6 +80904,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76676,6 +80923,7 @@
 		"songID": 710,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76694,6 +80942,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76712,6 +80961,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76730,6 +80980,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76748,6 +80999,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76766,6 +81018,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76784,6 +81037,7 @@
 		"songID": 711,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76802,6 +81056,7 @@
 		"songID": 712,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76820,6 +81075,7 @@
 		"songID": 712,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76838,6 +81094,7 @@
 		"songID": 712,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76856,6 +81113,7 @@
 		"songID": 712,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76874,6 +81132,7 @@
 		"songID": 712,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76892,6 +81151,7 @@
 		"songID": 712,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76910,6 +81170,7 @@
 		"songID": 713,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76928,6 +81189,7 @@
 		"songID": 713,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76946,6 +81208,7 @@
 		"songID": 713,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76964,6 +81227,7 @@
 		"songID": 713,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -76982,6 +81246,7 @@
 		"songID": 713,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77000,6 +81265,7 @@
 		"songID": 713,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77018,6 +81284,7 @@
 		"songID": 714,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77036,6 +81303,7 @@
 		"songID": 714,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77054,6 +81322,7 @@
 		"songID": 714,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77072,6 +81341,7 @@
 		"songID": 714,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77090,6 +81360,7 @@
 		"songID": 714,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77108,6 +81379,7 @@
 		"songID": 714,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77126,6 +81398,7 @@
 		"songID": 715,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77144,6 +81417,7 @@
 		"songID": 715,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77162,6 +81436,7 @@
 		"songID": 715,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77180,6 +81455,7 @@
 		"songID": 715,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77198,6 +81474,7 @@
 		"songID": 715,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77216,6 +81493,7 @@
 		"songID": 715,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77234,6 +81512,7 @@
 		"songID": 716,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77252,6 +81531,7 @@
 		"songID": 716,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77270,6 +81550,7 @@
 		"songID": 716,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77288,6 +81569,7 @@
 		"songID": 716,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77306,6 +81588,7 @@
 		"songID": 716,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77324,6 +81607,7 @@
 		"songID": 716,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77342,6 +81626,7 @@
 		"songID": 717,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77360,6 +81645,7 @@
 		"songID": 717,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77378,6 +81664,7 @@
 		"songID": 717,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77396,6 +81683,7 @@
 		"songID": 717,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77414,6 +81702,7 @@
 		"songID": 717,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77432,6 +81721,7 @@
 		"songID": 717,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77450,6 +81740,7 @@
 		"songID": 718,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77468,6 +81759,7 @@
 		"songID": 718,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77486,6 +81778,7 @@
 		"songID": 718,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77504,6 +81797,7 @@
 		"songID": 718,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77522,6 +81816,7 @@
 		"songID": 718,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77540,6 +81835,7 @@
 		"songID": 718,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77558,6 +81854,7 @@
 		"songID": 719,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77576,6 +81873,7 @@
 		"songID": 719,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77594,6 +81892,7 @@
 		"songID": 719,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77612,6 +81911,7 @@
 		"songID": 719,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77630,6 +81930,7 @@
 		"songID": 719,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77648,6 +81949,7 @@
 		"songID": 719,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77666,6 +81968,7 @@
 		"songID": 720,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77684,6 +81987,7 @@
 		"songID": 720,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77702,6 +82006,7 @@
 		"songID": 720,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77720,6 +82025,7 @@
 		"songID": 720,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77738,6 +82044,7 @@
 		"songID": 720,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77756,6 +82063,7 @@
 		"songID": 720,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77774,6 +82082,7 @@
 		"songID": 721,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77792,6 +82101,7 @@
 		"songID": 721,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77810,6 +82120,7 @@
 		"songID": 721,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77828,6 +82139,7 @@
 		"songID": 721,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77846,6 +82158,7 @@
 		"songID": 721,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77864,6 +82177,7 @@
 		"songID": 721,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77882,6 +82196,7 @@
 		"songID": 722,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77900,6 +82215,7 @@
 		"songID": 722,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77918,6 +82234,7 @@
 		"songID": 722,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77936,6 +82253,7 @@
 		"songID": 722,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77954,6 +82272,7 @@
 		"songID": 722,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77972,6 +82291,7 @@
 		"songID": 722,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -77990,6 +82310,7 @@
 		"songID": 723,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78008,6 +82329,7 @@
 		"songID": 723,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78026,6 +82348,7 @@
 		"songID": 723,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78044,6 +82367,7 @@
 		"songID": 723,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78062,6 +82386,7 @@
 		"songID": 723,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78080,6 +82405,7 @@
 		"songID": 723,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78098,6 +82424,7 @@
 		"songID": 724,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78116,6 +82443,7 @@
 		"songID": 724,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78134,6 +82462,7 @@
 		"songID": 724,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78152,6 +82481,7 @@
 		"songID": 724,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78170,6 +82500,7 @@
 		"songID": 724,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78188,6 +82519,7 @@
 		"songID": 724,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78206,6 +82538,7 @@
 		"songID": 725,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78224,6 +82557,7 @@
 		"songID": 725,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78242,6 +82576,7 @@
 		"songID": 725,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78260,6 +82595,7 @@
 		"songID": 725,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78278,6 +82614,7 @@
 		"songID": 725,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78296,6 +82633,7 @@
 		"songID": 725,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78314,6 +82652,7 @@
 		"songID": 726,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78332,6 +82671,7 @@
 		"songID": 726,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78350,6 +82690,7 @@
 		"songID": 726,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78368,6 +82709,7 @@
 		"songID": 726,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78386,6 +82728,7 @@
 		"songID": 726,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78404,6 +82747,7 @@
 		"songID": 726,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78422,6 +82766,7 @@
 		"songID": 727,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78440,6 +82785,7 @@
 		"songID": 727,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78458,6 +82804,7 @@
 		"songID": 727,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78476,6 +82823,7 @@
 		"songID": 727,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78494,6 +82842,7 @@
 		"songID": 727,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78512,6 +82861,7 @@
 		"songID": 727,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78530,6 +82880,7 @@
 		"songID": 728,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78548,6 +82899,7 @@
 		"songID": 728,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78566,6 +82918,7 @@
 		"songID": 728,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78584,6 +82937,7 @@
 		"songID": 728,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78602,6 +82956,7 @@
 		"songID": 728,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78620,6 +82975,7 @@
 		"songID": 728,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78638,6 +82994,7 @@
 		"songID": 729,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78656,6 +83013,7 @@
 		"songID": 729,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78674,6 +83032,7 @@
 		"songID": 729,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78692,6 +83051,7 @@
 		"songID": 729,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78710,6 +83070,7 @@
 		"songID": 729,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78728,6 +83089,7 @@
 		"songID": 729,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78746,6 +83108,7 @@
 		"songID": 730,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78764,6 +83127,7 @@
 		"songID": 730,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78782,6 +83146,7 @@
 		"songID": 730,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78800,6 +83165,7 @@
 		"songID": 730,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78818,6 +83184,7 @@
 		"songID": 730,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78836,6 +83203,7 @@
 		"songID": 730,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78854,6 +83222,7 @@
 		"songID": 731,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78872,6 +83241,7 @@
 		"songID": 731,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78890,6 +83260,7 @@
 		"songID": 731,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78908,6 +83279,7 @@
 		"songID": 731,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78926,6 +83298,7 @@
 		"songID": 731,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78944,6 +83317,7 @@
 		"songID": 731,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78962,6 +83336,7 @@
 		"songID": 732,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78980,6 +83355,7 @@
 		"songID": 732,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -78998,6 +83374,7 @@
 		"songID": 732,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79016,6 +83393,7 @@
 		"songID": 732,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79034,6 +83412,7 @@
 		"songID": 732,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79052,6 +83431,7 @@
 		"songID": 732,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79070,6 +83450,7 @@
 		"songID": 733,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79088,6 +83469,7 @@
 		"songID": 733,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79106,6 +83488,7 @@
 		"songID": 733,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79124,6 +83507,7 @@
 		"songID": 733,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79142,6 +83526,7 @@
 		"songID": 733,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79160,6 +83545,7 @@
 		"songID": 733,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79178,6 +83564,7 @@
 		"songID": 734,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79196,6 +83583,7 @@
 		"songID": 734,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79214,6 +83602,7 @@
 		"songID": 734,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79232,6 +83621,7 @@
 		"songID": 734,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79250,6 +83640,7 @@
 		"songID": 734,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79268,6 +83659,7 @@
 		"songID": 734,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79286,6 +83678,7 @@
 		"songID": 735,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79304,6 +83697,7 @@
 		"songID": 735,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79322,6 +83716,7 @@
 		"songID": 735,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79340,6 +83735,7 @@
 		"songID": 735,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79358,6 +83754,7 @@
 		"songID": 735,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79376,6 +83773,7 @@
 		"songID": 735,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79394,6 +83792,7 @@
 		"songID": 736,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79412,6 +83811,7 @@
 		"songID": 736,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79430,6 +83830,7 @@
 		"songID": 736,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79448,6 +83849,7 @@
 		"songID": 736,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79466,6 +83868,7 @@
 		"songID": 736,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79484,6 +83887,7 @@
 		"songID": 736,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79502,6 +83906,7 @@
 		"songID": 737,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79520,6 +83925,7 @@
 		"songID": 737,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79538,6 +83944,7 @@
 		"songID": 737,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79556,6 +83963,7 @@
 		"songID": 737,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79574,6 +83982,7 @@
 		"songID": 737,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79592,6 +84001,7 @@
 		"songID": 737,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79718,6 +84128,7 @@
 		"songID": 739,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79736,6 +84147,7 @@
 		"songID": 739,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79754,6 +84166,7 @@
 		"songID": 739,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79772,6 +84185,7 @@
 		"songID": 739,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79790,6 +84204,7 @@
 		"songID": 739,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79808,6 +84223,7 @@
 		"songID": 739,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79826,6 +84242,7 @@
 		"songID": 740,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79844,6 +84261,7 @@
 		"songID": 740,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79862,6 +84280,7 @@
 		"songID": 740,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79880,6 +84299,7 @@
 		"songID": 740,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79898,6 +84318,7 @@
 		"songID": 740,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79916,6 +84337,7 @@
 		"songID": 740,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79934,6 +84356,7 @@
 		"songID": 741,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79952,6 +84375,7 @@
 		"songID": 741,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79970,6 +84394,7 @@
 		"songID": 741,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -79988,6 +84413,7 @@
 		"songID": 741,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80006,6 +84432,7 @@
 		"songID": 741,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80024,6 +84451,7 @@
 		"songID": 741,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80042,6 +84470,7 @@
 		"songID": 742,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80060,6 +84489,7 @@
 		"songID": 742,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80078,6 +84508,7 @@
 		"songID": 742,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80096,6 +84527,7 @@
 		"songID": 742,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80114,6 +84546,7 @@
 		"songID": 742,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80132,6 +84565,7 @@
 		"songID": 742,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80150,6 +84584,7 @@
 		"songID": 743,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80168,6 +84603,7 @@
 		"songID": 743,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80186,6 +84622,7 @@
 		"songID": 743,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80204,6 +84641,7 @@
 		"songID": 743,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80222,6 +84660,7 @@
 		"songID": 743,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -80240,6 +84679,7 @@
 		"songID": 743,
 		"tierlistInfo": {},
 		"versions": [
+			"clan",
 			"festo"
 		]
 	},
@@ -97197,6 +101637,16206 @@
 		"tierlistInfo": {},
 		"versions": [
 			"festo"
+		]
+	},
+	{
+		"chartID": "08c058993e0a01693b6a59b5ac0f5c6196df1bc2",
+		"data": {
+			"inGameID": 10000003,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 901,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "aac3aba80234e1a0e904ff28ed2aaec2a4c35ff1",
+		"data": {
+			"inGameID": 10000003,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 901,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d098b5e0d0c2636eba4a6e7663d8270eb349a7d0",
+		"data": {
+			"inGameID": 10000003,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 901,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8a9cc7eb6e4994b66af73c10fafa782577214877",
+		"data": {
+			"inGameID": 10000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 901,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cda4c972179fcb317238e6080655aa9fa5e1ef2a",
+		"data": {
+			"inGameID": 10000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 901,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cbf813b95c01d9e0c709f772c4d4c3926a9c6630",
+		"data": {
+			"inGameID": 10000003,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 901,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "301205db9eafe2e4d77b4568bfb51cb08103ce80",
+		"data": {
+			"inGameID": 20000106,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 902,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3a4d0f38caf45353e3c0088c355d69ac3765d957",
+		"data": {
+			"inGameID": 20000106,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 902,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9212ccc80a2e325cd03b370d7eb0415fb83e52e3",
+		"data": {
+			"inGameID": 20000106,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 902,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f10b7375101df795ad3c6569e905e953398d9f74",
+		"data": {
+			"inGameID": 20000106,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 902,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "55e2351c4fec8447c0ad78946c292d7bbae70240",
+		"data": {
+			"inGameID": 20000106,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 902,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d26042343627014a249f24c397a9790d453bfb84",
+		"data": {
+			"inGameID": 20000106,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 902,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1582136559bbef997147e67070acea19da11b379",
+		"data": {
+			"inGameID": 20000109,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 903,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ea95198db5ed487faf1626441154a432f0a1473b",
+		"data": {
+			"inGameID": 20000109,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 903,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4b58a8ce9d492b177d78645bdc453c1a5cba24a4",
+		"data": {
+			"inGameID": 20000109,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 903,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6f7e320f77ad9d073a4a8c3a3b6ff55fc21ab449",
+		"data": {
+			"inGameID": 20000109,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 903,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2b41ab1959f1803a5b59cd949f8dcbfe481bd77b",
+		"data": {
+			"inGameID": 20000109,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 903,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7b1da16f1a5491aa20054130481e47f52e6b7750",
+		"data": {
+			"inGameID": 20000109,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 903,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "165d7e99141a245afdba2833f0fa9c4540275001",
+		"data": {
+			"inGameID": 20000110,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 904,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "911c22a0f0fa5422c76eefbddf09400d864be4f3",
+		"data": {
+			"inGameID": 20000110,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 904,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d7009fc9c9ec06e1422af7bb3ca9e31b41bf9393",
+		"data": {
+			"inGameID": 20000110,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 904,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f287f42a47573de91441a69dfd734ec5edffcdf7",
+		"data": {
+			"inGameID": 20000110,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 904,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f498d3d7aca5e601290caecabe172cdd5d7e29c0",
+		"data": {
+			"inGameID": 20000110,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 904,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7daed90224e118bb804531bfa99928b0c0e0f0b3",
+		"data": {
+			"inGameID": 20000110,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 904,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5d02992c069e13ac73983e6139ea528d0afd02b4",
+		"data": {
+			"inGameID": 30000012,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 905,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "09614c0b23ff082e349a5871b89dc96c4a6f54b1",
+		"data": {
+			"inGameID": 30000012,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 905,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d5cbf9211cdf813732a3d8a12888c007ef0411ac",
+		"data": {
+			"inGameID": 30000012,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 905,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6baa44f8e249d60254f5d6de543192e4acf053de",
+		"data": {
+			"inGameID": 30000012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 905,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1a4de2e2e8f1cabce2b1daf71197ae2d44c84491",
+		"data": {
+			"inGameID": 30000012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 905,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e4d989719962d5e0ae43dd71ab8685d472ae6a9e",
+		"data": {
+			"inGameID": 30000012,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 905,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "15b2a533e718dbb8531097da60eb9b7ffb41d612",
+		"data": {
+			"inGameID": 30000024,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 906,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c9e24427a0df9ddf787c29d8160b38a8ad168287",
+		"data": {
+			"inGameID": 30000024,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 906,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "eed5cacf7e45c2ce2a28996fac93d4cdbc4de13e",
+		"data": {
+			"inGameID": 30000024,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 906,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d616054cac9c5bdb75971aab84bd8728eeda9fb7",
+		"data": {
+			"inGameID": 30000024,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 906,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "681343afd54c9e8c1d4046d1b97ffcda9878924a",
+		"data": {
+			"inGameID": 30000024,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 906,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "59b35b6e144da83dfb85ba0dd5fa33371caf93ea",
+		"data": {
+			"inGameID": 30000024,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 906,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "76f6107c31ddebc6578e3e34e30fdd8564d38e8e",
+		"data": {
+			"inGameID": 30000052,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 907,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "616d3ef0c71a67a26afe535acc81359cdd2f4311",
+		"data": {
+			"inGameID": 30000052,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 907,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b0ff6d1bef81ea5f3a89caa2f3fd2f6a9808ab10",
+		"data": {
+			"inGameID": 30000052,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 907,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5b87185ac5ef74c39a4f637133b291b4d08cf6fc",
+		"data": {
+			"inGameID": 30000052,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 907,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b3fdde4de6411dcca7037df8b4d659a728517799",
+		"data": {
+			"inGameID": 30000052,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 907,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ad4596d6e8f013abbfa1f66c6ae7cc1abda2d016",
+		"data": {
+			"inGameID": 30000052,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 907,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "13accf5d251acb448011dde9b30fc3e8fa469b11",
+		"data": {
+			"inGameID": 40000028,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 908,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0861a746bf41e10138b530e0d6cd050281b289d0",
+		"data": {
+			"inGameID": 40000028,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 908,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "000b95b11f62f4d8b684be9ae50776220f6ab8e5",
+		"data": {
+			"inGameID": 40000028,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 908,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cedc22ce91ecdeae80c34681c5061ee7ed8398fa",
+		"data": {
+			"inGameID": 40000028,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 908,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "469968a777bf5b530dc0308473484784ef88d97e",
+		"data": {
+			"inGameID": 40000028,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 908,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6c26c83fa1d2b66a058048728c0ae613f3a15d23",
+		"data": {
+			"inGameID": 40000028,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 908,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "93010973d2b40c34ebd277929bafc57216744259",
+		"data": {
+			"inGameID": 50000053,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 909,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5c5906537d1e59df8244f65dd811d7953ddfaa42",
+		"data": {
+			"inGameID": 50000053,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 909,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "67a99d9d256894ec6ec439d902cd560a1a67e05e",
+		"data": {
+			"inGameID": 50000053,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 909,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "94c005970f4b048744b03b58e1c8bec9d522f433",
+		"data": {
+			"inGameID": 50000053,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 909,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e8c882222b994dafab9a23bba81ffbe0bb8b3b4d",
+		"data": {
+			"inGameID": 50000053,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 909,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e0186607f9f7868156471c0ea4a9916839b7695e",
+		"data": {
+			"inGameID": 50000053,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 909,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "56ec761f19e5dd3b078fabbfbe4424f4fd87dc9d",
+		"data": {
+			"inGameID": 50000064,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 910,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5d8a4dca9f376677c3f1f5b6f03943a1542d8c03",
+		"data": {
+			"inGameID": 50000064,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 910,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6f110446d5ceac9ab5e55017aeb56b25c90c2dd7",
+		"data": {
+			"inGameID": 50000064,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 910,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "db25f83c0232df7a6fa09477358de4069f6ec2fa",
+		"data": {
+			"inGameID": 50000064,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 910,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "996dfe769d6132e2fdf4e5619cb0ab6b6a8022d7",
+		"data": {
+			"inGameID": 50000064,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 910,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "92d13727bdbe8ecd69f5ccd4cba3355fc43b5e1f",
+		"data": {
+			"inGameID": 50000064,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 910,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4fc0195073968b354df3e76b544b82cb7377c8f0",
+		"data": {
+			"inGameID": 50000066,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 911,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8ca744bf9502ed3fce91c60bbe2073ca4062a6d9",
+		"data": {
+			"inGameID": 50000066,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 911,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "77f418f203ea719d143c75de0a3a3e6632d11fc7",
+		"data": {
+			"inGameID": 50000066,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 911,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3f3d1e4240c62c70fd9c58423e651a0adb60d60c",
+		"data": {
+			"inGameID": 50000066,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 911,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "80cbd02a08760cfb2088a884509024dcb731dbea",
+		"data": {
+			"inGameID": 50000066,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 911,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9eec5c47d0763d371ead692d05f8db5b2b981268",
+		"data": {
+			"inGameID": 50000066,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 911,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f102ef707a9095250fef96a8da5639d5c0145c53",
+		"data": {
+			"inGameID": 50000068,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 912,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4953d41cbdfa5669dcd60c4fb033cb6765b72303",
+		"data": {
+			"inGameID": 50000068,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 912,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cc2f6aee3671ec800873699dc702dbdb0fe6668a",
+		"data": {
+			"inGameID": 50000068,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 912,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f9bc0d26960f43513c428350346b3cbdc7182608",
+		"data": {
+			"inGameID": 50000068,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 912,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1069c22bf49da6a5eef73d0c7e2f5c7d3a916a81",
+		"data": {
+			"inGameID": 50000068,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 912,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e0df76abb35a41cf9c853659128e768d7ba3f86d",
+		"data": {
+			"inGameID": 50000068,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 912,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "814d14dd361d514b2b7091bb7fc3041f6b297374",
+		"data": {
+			"inGameID": 50000069,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 913,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5daf6b997a49f0a354f46199ab0eb3b8d3a18b49",
+		"data": {
+			"inGameID": 50000069,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 913,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c81420583348cdad2281a608fe803a75515a940f",
+		"data": {
+			"inGameID": 50000069,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 913,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8430ac687a585033cb9a429faff05ea69e556032",
+		"data": {
+			"inGameID": 50000069,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 913,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e433c38c7c967a22d5ada1541eb095c7c0aabcbc",
+		"data": {
+			"inGameID": 50000069,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 913,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "971c80d7b6ed89bf16bf3c4e91d77dc951dfaef8",
+		"data": {
+			"inGameID": 50000069,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 913,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b69402e47a3d2037ba9d48bf3cf90e736a858a70",
+		"data": {
+			"inGameID": 50000103,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 914,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "63c210a817d6a6fb06ac9ea000f417efcb4ff1e1",
+		"data": {
+			"inGameID": 50000103,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 914,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "618932e0b5cfc345e47a3d36b6521a20af9771c6",
+		"data": {
+			"inGameID": 50000103,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 914,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6f6f621d8db29100cd9ec8df33f1360887a2cd47",
+		"data": {
+			"inGameID": 50000103,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 914,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "16a5483dce498fc83c81c6e482a5d655ea30929f",
+		"data": {
+			"inGameID": 50000103,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 914,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "461a4ce00a9d28b3e057d0ba9d63439ddf390e48",
+		"data": {
+			"inGameID": 50000103,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 914,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ba312f32d7dbb1d35c761fa75030149ba34e640c",
+		"data": {
+			"inGameID": 50000106,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 915,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9535fe45a8b5a5f07f329efc95ba868c188c3332",
+		"data": {
+			"inGameID": 50000106,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 915,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "54c977cef8d0cdd3d54bc0e2cd025157466008d6",
+		"data": {
+			"inGameID": 50000106,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 915,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "39820bb1f5293780d500a4a5d08802666fdeda7a",
+		"data": {
+			"inGameID": 50000106,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 915,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "de31968e14d007a97e5b5b03beb97a3d1b3ada4c",
+		"data": {
+			"inGameID": 50000106,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 915,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3cc3ae77b9046ce8182695d3a9c13b6ff6d3cdbe",
+		"data": {
+			"inGameID": 50000106,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 915,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f2a0448dcd74faba80e1a89e62c42c80ee6d02dc",
+		"data": {
+			"inGameID": 50000153,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 916,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fad0ec09281627197c8eff793c837b0e94407573",
+		"data": {
+			"inGameID": 50000153,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 916,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6a07c4a18232707045613afa7d172bbb85f08b4b",
+		"data": {
+			"inGameID": 50000153,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 916,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b8ad5ed3298b50cc8b4c5f27d89672e87756982f",
+		"data": {
+			"inGameID": 50000153,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 916,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a24b1eb625af7e3531cca395e3504d16b491075c",
+		"data": {
+			"inGameID": 50000153,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 916,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6857460f3ee85057089a2646c4d26175cf0547bf",
+		"data": {
+			"inGameID": 50000153,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 916,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "46e53ca26331fd86d1950b04495ba455cb9b9a02",
+		"data": {
+			"inGameID": 50000163,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 917,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "db4ac0523c00963fcc9588529897a2e634b69109",
+		"data": {
+			"inGameID": 50000163,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 917,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "56d4525509f22ad13e9c126d3fe05fcdfdc26941",
+		"data": {
+			"inGameID": 50000163,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 917,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c4cf3c600fff2bf817d2d4c7982f4c4bb5f6030f",
+		"data": {
+			"inGameID": 50000163,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 917,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "49384f9d8265b51eb71eaef1e13560c31f73d304",
+		"data": {
+			"inGameID": 50000163,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 917,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "88822ef019b2fc2bb43cf434908895ec7f5a12fc",
+		"data": {
+			"inGameID": 50000163,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 917,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a5a012e40f16d6bf076ac9c2801dd58f5754f51a",
+		"data": {
+			"inGameID": 50000168,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 918,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "45091202187f45a89a24af4ac60dbb1e9e580910",
+		"data": {
+			"inGameID": 50000168,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 918,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "95c7f79413a6f0e7f92304dc7a3670190ce0fc19",
+		"data": {
+			"inGameID": 50000168,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 918,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4d342a5c372f66d5ed2ffe7fe387546b4d29f548",
+		"data": {
+			"inGameID": 50000168,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 918,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "da2b9e0ab1779badc9f185057594ba6aac69ffa8",
+		"data": {
+			"inGameID": 50000168,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 918,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e8442f0e3133fc7aef1b709a10d8e2ad7ea159a9",
+		"data": {
+			"inGameID": 50000168,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 918,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d4eb9823726bd2c33c7da16fc52eaaaf222540d9",
+		"data": {
+			"inGameID": 50000169,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 919,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6bbdab8e48110cee0e545e46a1781c95de8e9517",
+		"data": {
+			"inGameID": 50000169,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 919,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b4baee4ad9005c79a809d0be5dea237b1324c565",
+		"data": {
+			"inGameID": 50000169,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 919,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "adf4b6d98dab22821f41eacbb8e84256f700db54",
+		"data": {
+			"inGameID": 50000169,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 919,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d7b28926df91c26f8552c42111df4eeb19932f57",
+		"data": {
+			"inGameID": 50000169,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 919,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a8a411c8dc29817707de7fc75c93dcab27981134",
+		"data": {
+			"inGameID": 50000169,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 919,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0ca7286390213035a00a49a9210c3a97168f6f6e",
+		"data": {
+			"inGameID": 50000192,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 920,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b891590bf369f6223334c4ef63dbc91331f25ba6",
+		"data": {
+			"inGameID": 50000192,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 920,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "540c367164e6161685c33d0efa075f75a649d92a",
+		"data": {
+			"inGameID": 50000192,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 920,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "04f869b37626651de4b09d31371f913c32bf3116",
+		"data": {
+			"inGameID": 50000192,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 920,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "01c2e4c9aac20d71eb7c8e3a0471a2c52bc3961a",
+		"data": {
+			"inGameID": 50000192,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 920,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3215e8ae2c42beb288bfd6ecde78c4f787f2195c",
+		"data": {
+			"inGameID": 50000192,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 920,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bf4ac0c670a8dff73ae68fb1175de7574bf84c8b",
+		"data": {
+			"inGameID": 50000193,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 921,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c586b1db9e0d944dacded50dbd99e7b70845efb0",
+		"data": {
+			"inGameID": 50000193,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 921,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1e433b4989685c5c5866314ed38abd6b314b2510",
+		"data": {
+			"inGameID": 50000193,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 921,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5526209dcc922c806b8eabd4a1e516a154044b64",
+		"data": {
+			"inGameID": 50000193,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 921,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e57e9bd9ad0501b7da297ce908165829794e7c5a",
+		"data": {
+			"inGameID": 50000193,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 921,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "19ebd8a878bfa8a772a09b3d0451f1b00b9c16e1",
+		"data": {
+			"inGameID": 50000193,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 921,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f0592a9d767b2d00a30f5f94ecdc47f3b74fb1ee",
+		"data": {
+			"inGameID": 50000194,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 922,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "42ab549aec9281e5957d64b3fd1b9f40626e31eb",
+		"data": {
+			"inGameID": 50000194,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 922,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ef48a9c63c5bda681c54f72174d48ac3739c4f01",
+		"data": {
+			"inGameID": 50000194,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 922,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bf807f369a181098fa07cc9f1c1f6e0c278baf95",
+		"data": {
+			"inGameID": 50000194,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 922,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b3251f273a71f8deb118d6ec3e88f6053a074c2e",
+		"data": {
+			"inGameID": 50000194,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 922,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e40b9a38dbab249a2e72ccd331d6e6c1c8c99e48",
+		"data": {
+			"inGameID": 50000194,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 922,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "90b00b0dd540d970f3506c853f48ddba5459d87e",
+		"data": {
+			"inGameID": 50000211,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 923,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ed6b9fbbc9272f477ac3813729750bd30f0f46e4",
+		"data": {
+			"inGameID": 50000211,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 923,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "573df38a3293e4cdb27b934eb7af5edebf2a259a",
+		"data": {
+			"inGameID": 50000211,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 923,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fd0de3630da3aa15c7fb7f63363323214287e9ac",
+		"data": {
+			"inGameID": 50000211,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 923,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3542ea97ede6ffc6417c3a07838a051e19ef217d",
+		"data": {
+			"inGameID": 50000211,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 923,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a14c2912aa819259192c61ec845d43ae7c51c979",
+		"data": {
+			"inGameID": 50000211,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 923,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e1e1a23431c376fa60005fc511bed54205eedd8b",
+		"data": {
+			"inGameID": 50000217,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 924,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "594ddf20c2209ba6a989660593c1270095c2c1be",
+		"data": {
+			"inGameID": 50000217,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 924,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "44963f1214ad2db782f59cc4432d87ccbe42fee6",
+		"data": {
+			"inGameID": 50000217,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 924,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "64d8c702c86c10a7a3b4cac07d74a2150e2f7272",
+		"data": {
+			"inGameID": 50000217,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 924,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6154d590ee8e6513d2f70d36284184f26b950c8b",
+		"data": {
+			"inGameID": 50000217,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 924,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "94215100ddbeb1ca9728f8a2965acde31d0d04c4",
+		"data": {
+			"inGameID": 50000217,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 924,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bdcdf6f99a30468f3711eeafc450c2ed5ddf69fa",
+		"data": {
+			"inGameID": 50000218,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 925,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9ac32b391af44ed51d2af8b7798e412292f5caff",
+		"data": {
+			"inGameID": 50000218,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 925,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b3e09dc5f82c59936432cb4d83650c7fa73024ba",
+		"data": {
+			"inGameID": 50000218,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 925,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "64352b0e1dfff2eb656d08dac793347fdbd0ce3b",
+		"data": {
+			"inGameID": 50000218,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 925,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "59459f033fd991fe8639e6f7e1ad5dbd1059516b",
+		"data": {
+			"inGameID": 50000218,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 925,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "406985823998d550bda5dcd779b1f82e2f9e2e66",
+		"data": {
+			"inGameID": 50000218,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 925,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9a184ba62e1e4bce95d07db84ccc5458d6200d90",
+		"data": {
+			"inGameID": 50000222,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 926,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d325c5c986c19f3dd6819c5586dade040f464aa8",
+		"data": {
+			"inGameID": 50000222,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 926,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "60ba18e60eba0e4de40baf4275afa47e390de89f",
+		"data": {
+			"inGameID": 50000222,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 926,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "12afbf2e85874ac86d139e2e9630f12f34d3c20f",
+		"data": {
+			"inGameID": 50000222,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 926,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9c11719f3dda6f1c72542a32ea242d2ea3cb77fe",
+		"data": {
+			"inGameID": 50000222,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 926,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "67afe299d31f6e7ada84fa4d8b33ee9730b5081a",
+		"data": {
+			"inGameID": 50000222,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 926,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7d34d580497eb70b1acf22637df603585de0552a",
+		"data": {
+			"inGameID": 50000223,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 927,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5f205cfdf61243dab093235f300c149d7e5cf1fb",
+		"data": {
+			"inGameID": 50000223,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 927,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a3f9f74eaa3fb6d4686c51fe017bd80197b0d1b1",
+		"data": {
+			"inGameID": 50000223,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 927,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "da36436d1163fac0799c7feb5eab6bb9c7eea99a",
+		"data": {
+			"inGameID": 50000223,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 927,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "48dea07b0ae923935565b92fbb6c3757a33ae074",
+		"data": {
+			"inGameID": 50000223,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 927,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b4705cc6e11e23717e5c42c8d3839dd30140f0bb",
+		"data": {
+			"inGameID": 50000223,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 927,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f6a845e069895ca549c7f6e787c169080aeeae8b",
+		"data": {
+			"inGameID": 50000224,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 928,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9d785d03fec926aba7ece6e8036e77c4459cb4c3",
+		"data": {
+			"inGameID": 50000224,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 928,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ecb72a536962286e1307195d24afdaaf9975a020",
+		"data": {
+			"inGameID": 50000224,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 928,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d82cd81f33e54a68db7e0855964e02690b52181f",
+		"data": {
+			"inGameID": 50000224,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 928,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7aac455f3fc8a42249c70a6ce70709eba500034a",
+		"data": {
+			"inGameID": 50000224,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 928,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6e4f343e84d98af0d38bbf8d9383ff5357af14b7",
+		"data": {
+			"inGameID": 50000224,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 928,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3ff36adcc9e7b0c33756f0b369d293c89d1d3665",
+		"data": {
+			"inGameID": 50000226,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 929,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4614e09633dd317cde39acfa12d711046168bf8b",
+		"data": {
+			"inGameID": 50000226,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 929,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9654aaae0c7a10aabd38598facb885b7d833a999",
+		"data": {
+			"inGameID": 50000226,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 929,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f43f600d154c9db2236cfdebdc0dfcdc95d241e6",
+		"data": {
+			"inGameID": 50000226,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 929,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e921bf69b073064dec47889751fddb2a80913b2d",
+		"data": {
+			"inGameID": 50000226,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 929,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7809f6cd205f20736058e4d1ebc8f0b777132c75",
+		"data": {
+			"inGameID": 50000226,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 929,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2ed07d83a3b74533793f10a3750f891da05b1825",
+		"data": {
+			"inGameID": 50000231,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 930,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "26c86ca2e3b08d67399954e608d14b40c5d0bc54",
+		"data": {
+			"inGameID": 50000231,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 930,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ae301beb54b73131a0479e0ed0231b9eb425a56d",
+		"data": {
+			"inGameID": 50000231,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 930,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8f4e45e53e0bbbfe330a9de3bbb125bb5c3c7df4",
+		"data": {
+			"inGameID": 50000231,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 930,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "93d808cfc6494394f063bf6e126b2297d1778c39",
+		"data": {
+			"inGameID": 50000231,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 930,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0f1ad16b0cbad8b85ddd860a1be69aed25e4877d",
+		"data": {
+			"inGameID": 50000231,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 930,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6962f06d44e4b386b3ad5de4997847f97d2a0be3",
+		"data": {
+			"inGameID": 50000246,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 931,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d7632f7e35631db935f4691b8af01050b0f44dcd",
+		"data": {
+			"inGameID": 50000246,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 931,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "59c199a4a89f64a1d161043e8e2e84b57c39c4c2",
+		"data": {
+			"inGameID": 50000246,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 931,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3d9aeba4c0917099cf6a51fd2cc1bc73ea430266",
+		"data": {
+			"inGameID": 50000246,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 931,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bcfb7cb4f92c134ab2cd6e77ff4476364b7ba38f",
+		"data": {
+			"inGameID": 50000246,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 931,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b02ad3615450e077c6c4a73d1a5d87cb6121c292",
+		"data": {
+			"inGameID": 50000246,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 931,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "953bafb4ede87dde5cac397eccc4b2fd04a8ec26",
+		"data": {
+			"inGameID": 50000247,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 932,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3717d4ba55f18444ae569531d61d2ef0c83f03a5",
+		"data": {
+			"inGameID": 50000247,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 932,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1752262c90bc6db12f5f0416eafec5b31f142880",
+		"data": {
+			"inGameID": 50000247,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 932,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1f9cebd13a923be75616652e244893cf0cfce950",
+		"data": {
+			"inGameID": 50000247,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 932,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "db3609c662bc99a3c098a532553194600ea29914",
+		"data": {
+			"inGameID": 50000247,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 932,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "291daa470de0b289fb25e4c8e02241f8f1221e69",
+		"data": {
+			"inGameID": 50000247,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 932,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0328343cc49c8a77d5dca90e7a17ab34d2775964",
+		"data": {
+			"inGameID": 50000326,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 933,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "846c887a3e5d7a51af71f045cad201d6b528c165",
+		"data": {
+			"inGameID": 50000326,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 933,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ad0e6baf123d90daa446dde33ef5db39478d4b47",
+		"data": {
+			"inGameID": 50000326,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 933,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5eefb344663a1103b25fd1e572946ff6f1d0311f",
+		"data": {
+			"inGameID": 50000326,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 933,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1e3cb130acf505249d936bfb6d811f9806d544ec",
+		"data": {
+			"inGameID": 50000326,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 933,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "949249f69e31430e8eac0e5ed7fadbed2beebc0b",
+		"data": {
+			"inGameID": 50000326,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 933,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "43807c1596dc5d550cd66cfb84b1c2ada6bfbd15",
+		"data": {
+			"inGameID": 50000360,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 934,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ec74f3f573b78998c05b4e69599a645b5622661a",
+		"data": {
+			"inGameID": 50000360,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 934,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "122943a9260ae4c94d438382f63edc661619817e",
+		"data": {
+			"inGameID": 50000360,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 934,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1fc0c148036a1535514210dff974d602d945bc73",
+		"data": {
+			"inGameID": 50000360,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 934,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2fa1291f3929949044a4d5d960a8c9e805da17de",
+		"data": {
+			"inGameID": 50000360,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 934,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "43e5c83c852c3de77c7e83128ea44552f673291e",
+		"data": {
+			"inGameID": 50000360,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 934,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fdad6b75224e99c1518244d6f69d9d61819f9c80",
+		"data": {
+			"inGameID": 50000362,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 935,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "eda0880c09e2dd634567eb58d7c26e7f902b7472",
+		"data": {
+			"inGameID": 50000362,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 935,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5150564658ac5db83c99ee6d19b9f997610608bf",
+		"data": {
+			"inGameID": 50000362,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 935,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5d53fc5dba82cd708f2b6fd2b56ffd9235232ef2",
+		"data": {
+			"inGameID": 50000362,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 935,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "11135d5a24193040dd318b47f08eb9729644ca2d",
+		"data": {
+			"inGameID": 50000362,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 935,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e35243c9f50d7dd2da80166a889521601cdf32fe",
+		"data": {
+			"inGameID": 50000362,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 935,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "21f4ed0caf0a3402f8bb7f1e153b19cd43366fb2",
+		"data": {
+			"inGameID": 50000363,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 936,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "49bddb8d8950296bfbd729beaff440312b2debfa",
+		"data": {
+			"inGameID": 50000363,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 936,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f59b5053b9b0d3cac928c80e68ce1f5af213ecd8",
+		"data": {
+			"inGameID": 50000363,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 936,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f760c9c3ee3590bff002f9fcb8e6283efa03251b",
+		"data": {
+			"inGameID": 50000363,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 936,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c696f9fa8a9b2968e5c11fdf9637dcb4d469cd8d",
+		"data": {
+			"inGameID": 50000363,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 936,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7f6f6278120296a858878e06481444c9468f4218",
+		"data": {
+			"inGameID": 50000363,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 936,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "76a0a9c84d1e1a996128eaf45d184d0283a5f175",
+		"data": {
+			"inGameID": 60000087,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 937,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f64b859176e8ae66fd4eaf05d6bc79b99bbf0a4f",
+		"data": {
+			"inGameID": 60000087,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 937,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "48ca1e37e5351477824a7871e92f8401e4ecbde2",
+		"data": {
+			"inGameID": 60000087,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 937,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "00bad92d7e27e788161842795f8ecde5d1f64d52",
+		"data": {
+			"inGameID": 60000087,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 937,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1d86c8dceb865d81ad39fb84d01c5d53cf6f4529",
+		"data": {
+			"inGameID": 60000087,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 937,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c9659c9824d96516663ded6a62f7aab034c0e714",
+		"data": {
+			"inGameID": 60000087,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 937,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "55ee8c150e56cc670199ed2de5d4f1e605330eaa",
+		"data": {
+			"inGameID": 60000091,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 938,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "13556d0f62edd1fef7347a1979833db38645c2e4",
+		"data": {
+			"inGameID": 60000091,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 938,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cb81449347f456c999edf7a079386b889c00ba35",
+		"data": {
+			"inGameID": 60000091,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 938,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "08236326ef983a860fdfa62a529f28f7013727bd",
+		"data": {
+			"inGameID": 60000091,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 938,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5c9d3b4b31e97d81056ca588e38d751d7583eaab",
+		"data": {
+			"inGameID": 60000091,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 938,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7a464df5980d2225556ff44d233dc31ae42b9dbc",
+		"data": {
+			"inGameID": 60000091,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 938,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c7edd220f39e5ecac18aab42404865a6741dfedf",
+		"data": {
+			"inGameID": 60000093,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 939,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "544eeb13aff65add54361d9c198f936a18c3d214",
+		"data": {
+			"inGameID": 60000093,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 939,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8da452970a34f77c11873844f08bfac9f10a2c82",
+		"data": {
+			"inGameID": 60000093,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 939,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "127256c451d2238ecd88c370fdd165d5858462da",
+		"data": {
+			"inGameID": 60000093,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 939,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2497fa2a695df171dac2d7cff81b7f40567a11dd",
+		"data": {
+			"inGameID": 60000093,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 939,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e14be6356f137ca5ada76537a8dcd52b6cf790d3",
+		"data": {
+			"inGameID": 60000093,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 939,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2ccc3292bd2f889976a0d4fae032cc43ca7e4780",
+		"data": {
+			"inGameID": 60000095,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 940,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "06a2d2df86f648668639a5d56536592a6c350749",
+		"data": {
+			"inGameID": 60000095,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 940,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fe1897302b90d2523145d9adaec3a8353274a9be",
+		"data": {
+			"inGameID": 60000095,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 940,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c0075bae4277c3eed87e800c7ed48624f326443d",
+		"data": {
+			"inGameID": 60000095,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 940,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b6f1f5717aa7c07f344ae11ed4f16f2c7cdeeecb",
+		"data": {
+			"inGameID": 60000095,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 940,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "071e49fb6f858130dd86d20a5ebe8b81f4f55b77",
+		"data": {
+			"inGameID": 60000095,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 940,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1d72bf18244095a6c6c811f4cd7a6d4bcbb26fe6",
+		"data": {
+			"inGameID": 60000096,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 941,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1398ec731d3e11bb5c4168898a550153a7a9aaab",
+		"data": {
+			"inGameID": 60000096,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 941,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7f264f738b2db730322a1932b7d33a97d9679984",
+		"data": {
+			"inGameID": 60000096,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 941,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8561d41e33707239b7dcd0ec77d87402c761d4ea",
+		"data": {
+			"inGameID": 60000096,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 941,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "16affe5358c1e3092ad504c60c9daa9c7a87bf5b",
+		"data": {
+			"inGameID": 60000096,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 941,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c2398b0831ff1106aa151dacdfb6451afd291128",
+		"data": {
+			"inGameID": 60000096,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 941,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9383b2a90ee0acff5e4f62b83e9170a2c3964b0c",
+		"data": {
+			"inGameID": 60000097,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 942,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2503f46ac04eebf9a3b57c67178b72e66bac339f",
+		"data": {
+			"inGameID": 60000097,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 942,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "651f3fa41e5f2b75025b15c74ce14e8e8b1dcc2f",
+		"data": {
+			"inGameID": 60000097,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 942,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "49643e0a625c9bb2d8b045bb7761a38a4ad36ff1",
+		"data": {
+			"inGameID": 60000097,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 942,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "643dee9184717991a04b880ac92cec6d1c24088d",
+		"data": {
+			"inGameID": 60000097,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 942,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "78e9d6456c4e5a62ad37d7c3b03dd5e6db0e093f",
+		"data": {
+			"inGameID": 60000097,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 942,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5fcc18c89646551d0e8abc9e7ef186e8ec4abbe8",
+		"data": {
+			"inGameID": 60000098,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 943,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e8350ea801ad2960cfd94b390dd406df6344549f",
+		"data": {
+			"inGameID": 60000098,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 943,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e21bfccd9e0132f7d07752b25acb80002ce2c4ae",
+		"data": {
+			"inGameID": 60000098,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 943,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2e88f753976c86e8912c5b081547dff9d4e03c25",
+		"data": {
+			"inGameID": 60000098,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 943,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "053ccdcb47c362cb6e8f2e674652fbb73d127772",
+		"data": {
+			"inGameID": 60000098,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 943,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bb23bc35d9bc86a973a6c71403f68d357edd94f4",
+		"data": {
+			"inGameID": 60000098,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 943,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "51db05f30fd48210160eba76f1ad5c75093ba230",
+		"data": {
+			"inGameID": 60000099,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 944,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7bd6245e0eddcab52516895ca0687e636b97ba6f",
+		"data": {
+			"inGameID": 60000099,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 944,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "190ba8f084ffa89a9852e0d19005d7322ccfc5ea",
+		"data": {
+			"inGameID": 60000099,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 944,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2cb980e52a5ac18e3acde82710daa90b929dd9da",
+		"data": {
+			"inGameID": 60000099,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 944,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b523caa9c3a0f3cc7336b8c982bd55a71c8e4cab",
+		"data": {
+			"inGameID": 60000099,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 944,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "529fcae113fef2a1a1410e25efb9a9acd6d3eb1d",
+		"data": {
+			"inGameID": 60000099,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 944,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c36d922dac2e93c6ac14ef1b25f8e0d1d18c6a4b",
+		"data": {
+			"inGameID": 60000109,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 945,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5d5a89e996e39579e2860a1e8afb0aeab1111fd8",
+		"data": {
+			"inGameID": 60000109,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 945,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "78c26d082a1c5869ce98d57f0649567378ea9e7d",
+		"data": {
+			"inGameID": 60000109,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 945,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c0d46ffe28c6d57a5142454dc8456f880b3da837",
+		"data": {
+			"inGameID": 60000109,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 945,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d1f973b385a199acf6001d9d4337c8b83f4aedb9",
+		"data": {
+			"inGameID": 60000109,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 945,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b08ee4ea109ed5b91101110f9bdd1db8439c493d",
+		"data": {
+			"inGameID": 60000109,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 945,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f14e034c9a3533dfde0356b33b0291cd011ecad0",
+		"data": {
+			"inGameID": 60000124,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 946,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "163e12f1167575ba6ef5f16206d16d92a631395d",
+		"data": {
+			"inGameID": 60000124,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 946,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7d211a3060270bb31f6f813131789bb4f68a683c",
+		"data": {
+			"inGameID": 60000124,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 946,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bd8d0234b6508e5957a2e5239ebefacd1e884cd1",
+		"data": {
+			"inGameID": 60000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 946,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3dee9cd69290660b1947900ff83d8f5ed8f4503a",
+		"data": {
+			"inGameID": 60000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 946,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "073e1a6c9045cae81d9a85869451352e3f943ee1",
+		"data": {
+			"inGameID": 60000124,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 946,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "17c2f4c4968bb80b6f4099fa63a6db4336cf0dda",
+		"data": {
+			"inGameID": 60001011,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 947,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2638af5c25970368153933b80f2febfb4b196cb4",
+		"data": {
+			"inGameID": 60001011,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 947,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0975704341a940f35aad1d8c20e14cf0d9fadd38",
+		"data": {
+			"inGameID": 60001011,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 947,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0a674a22979e6bb3cad1b6ccbc7b2442589f90ae",
+		"data": {
+			"inGameID": 60001011,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 947,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7f6b2284c615d3a1ded0a0952453b574c6d44b83",
+		"data": {
+			"inGameID": 60001011,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 947,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "10da0cc53b2b91804f243ab6eaf40e3d99bd8841",
+		"data": {
+			"inGameID": 60001011,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 947,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6256349cc712848ddc094fea333ea9efc122ea56",
+		"data": {
+			"inGameID": 60001014,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 948,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6065ca986001b38e95dbc2028575676d7e81fdd4",
+		"data": {
+			"inGameID": 60001014,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 948,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "669cbaf6993337eef9f7f7cf7714f5c871864f3d",
+		"data": {
+			"inGameID": 60001014,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 948,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "661b587c95b06025c896e026d081b98c98550742",
+		"data": {
+			"inGameID": 60001014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 948,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a33f790485717a80292be1aa73b36dd37898d8e5",
+		"data": {
+			"inGameID": 60001014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 948,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5d64f8146ca62b2ce5b4bbd480b49deb65d5a99d",
+		"data": {
+			"inGameID": 60001014,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 948,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8b22fd075a7cf82462f4d11e755152cfe7b3530f",
+		"data": {
+			"inGameID": 60001015,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 949,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b7bc3caa1b7efe863bf819382eb1f2317f0cd893",
+		"data": {
+			"inGameID": 60001015,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 949,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4c750ecbc2a11823ffa28287fc2f8f0147402a60",
+		"data": {
+			"inGameID": 60001015,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 949,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e1b603e043504fb7d7ddc92c7c6740dd5b487158",
+		"data": {
+			"inGameID": 60001015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 949,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8fccca5fdfff6b9a89bcfbef865856f35ac6dba6",
+		"data": {
+			"inGameID": 60001015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 949,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "01fb53da7ac235b61b98dc60c8bc7f2d52ee5afd",
+		"data": {
+			"inGameID": 60001015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 949,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b536c521cc1769603d653fd2c681b6212cf9937c",
+		"data": {
+			"inGameID": 70000013,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 950,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a04072b6e26d37f79c60e384020bcb27008869cf",
+		"data": {
+			"inGameID": 70000013,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 950,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "803a6602a36c7cff94651e31733c89baeb1d1c08",
+		"data": {
+			"inGameID": 70000013,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 950,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "79357a9082277aaa130760d1902de4da085e2530",
+		"data": {
+			"inGameID": 70000013,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 950,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ce80bf0c6323c9c8874ef7434c8a25a012baebb8",
+		"data": {
+			"inGameID": 70000013,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 950,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a8bb9f85f0544e03c494f623000d2154ce274a01",
+		"data": {
+			"inGameID": 70000013,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 950,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5e3be879368867aee4c966e084eaebe15b4c31a8",
+		"data": {
+			"inGameID": 70000015,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 951,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d484e48fd6aa91f07133dffbd39148f0214074ba",
+		"data": {
+			"inGameID": 70000015,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 951,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "130e8daab6c13d2e8457db862a48ff98c4aada4b",
+		"data": {
+			"inGameID": 70000015,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 951,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c9a466c644de6bb527cbf7ea663096670e97487e",
+		"data": {
+			"inGameID": 70000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 951,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2b17007d5be82103ccc9290ee32c314cde2e70f2",
+		"data": {
+			"inGameID": 70000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 951,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cb0be839b57305208b65500a66cf5afb83248e7e",
+		"data": {
+			"inGameID": 70000015,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 951,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "775ce6d8d16c3ffc942445f1215a25d0e1a7088f",
+		"data": {
+			"inGameID": 70000016,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 952,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cf5143290b8daf2ca1215b6b0492130c1e9ae19e",
+		"data": {
+			"inGameID": 70000016,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 952,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "267a02d80ee5a434604976bc72d8b25d16832fed",
+		"data": {
+			"inGameID": 70000016,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 952,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fe168e9ca2c1a8664ae52e8700fccbf6d0981781",
+		"data": {
+			"inGameID": 70000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 952,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5ba2edd1cd4dc8c7f379a296dc23ba2a8ebd2b1b",
+		"data": {
+			"inGameID": 70000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 952,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3c48c624270d06d6ae53a115901aed9339d96c9f",
+		"data": {
+			"inGameID": 70000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 952,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d637c9b933afe552fb1740a899867c26d19af557",
+		"data": {
+			"inGameID": 70000017,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 953,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "49f0b5a6f7411c93fd891c9486fca7904a88c668",
+		"data": {
+			"inGameID": 70000017,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 953,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "215680c1c92f3b1c31324c156e543310ccf993f0",
+		"data": {
+			"inGameID": 70000017,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 953,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d58bacac82fcaa80e5d431845a49e23312175f49",
+		"data": {
+			"inGameID": 70000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 953,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dca680d3bcd5c246f11a10fe43c4b499c014f051",
+		"data": {
+			"inGameID": 70000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 953,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "78e47a6b583fffe45a5cbae5690544e3dde8652e",
+		"data": {
+			"inGameID": 70000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 953,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2c2507558ad8004f2c5b3c7a8b6c139b70d18418",
+		"data": {
+			"inGameID": 70000018,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 954,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "03da9b284a9cedcc49ed63ba89558168e0d7f1b0",
+		"data": {
+			"inGameID": 70000018,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 954,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "be1dcffeaf7c12857bc1a5418e15fab5ffa58467",
+		"data": {
+			"inGameID": 70000018,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 954,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "acfcbc4a6b4c80c71dd3063060883c69906e53cb",
+		"data": {
+			"inGameID": 70000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 954,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "596b34727b3486f67e9142b6344ce1d6412d649b",
+		"data": {
+			"inGameID": 70000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 954,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f39dee321366f3fc5811623bf4af35f70562adf7",
+		"data": {
+			"inGameID": 70000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 954,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c0ab895be8380190a16ad14656058d1c931b98c5",
+		"data": {
+			"inGameID": 70000019,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 955,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "680bd435dcead953cff632d94932b7e6a4377038",
+		"data": {
+			"inGameID": 70000019,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 955,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6f4a448f1cec800695a907aaac7150cead6f1b88",
+		"data": {
+			"inGameID": 70000019,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 955,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9cb0456abe754139b292616414ce3cac8f882bc6",
+		"data": {
+			"inGameID": 70000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 955,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1ff716f3d4af17b334c6f0a9cdfe9547da7852c5",
+		"data": {
+			"inGameID": 70000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 955,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "da35fa2452d5aa8ab0c29af1c46b2893f00e7c2f",
+		"data": {
+			"inGameID": 70000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 955,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "42cf231101fcbcb9312d8f529fac84cc80b28b51",
+		"data": {
+			"inGameID": 70000020,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 956,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fd1ef5c24dd415886e9c81e082cd001917d65a43",
+		"data": {
+			"inGameID": 70000020,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 956,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "90a81758c38980f45119b0c59d985520184af95c",
+		"data": {
+			"inGameID": 70000020,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 956,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1bff5f2f82781e781950ae43fc6550af008cda88",
+		"data": {
+			"inGameID": 70000020,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 956,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1182c8d927c6987f151fee1ee6d15d6cc12c6aa8",
+		"data": {
+			"inGameID": 70000020,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 956,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6711f71cb191fc103e3eb777a3c37985ab5e92e1",
+		"data": {
+			"inGameID": 70000020,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 956,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "42f136149e83943a11e062ba752445938d346201",
+		"data": {
+			"inGameID": 70000022,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 957,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "437b11387755223e5b05d5b15f4daa901a622b3c",
+		"data": {
+			"inGameID": 70000022,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 957,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f9989885a8192396bd2ea74acac257eefa257864",
+		"data": {
+			"inGameID": 70000022,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 957,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a26e89d933ee58c09cd705c5ac5fc2a6affbc786",
+		"data": {
+			"inGameID": 70000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 957,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "992ad06d73da3dd829698589a11fecd8a4f18d67",
+		"data": {
+			"inGameID": 70000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 957,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3008458c23ef8cda591b564786066c1beafb7c71",
+		"data": {
+			"inGameID": 70000022,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 957,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dfa6ac936526b4b1823c8dabcfb3f555235ad4a8",
+		"data": {
+			"inGameID": 70000026,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 958,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "80cb354ae0f36f087f86febab91fddab45ba8b5e",
+		"data": {
+			"inGameID": 70000026,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 958,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "94ff6046b0a5fbe41e1136100253ff5ba17d665d",
+		"data": {
+			"inGameID": 70000026,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 958,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9dc3f3a6b1a9cbe75d37fcbe7126629e31b166bb",
+		"data": {
+			"inGameID": 70000026,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 958,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "14908317757059ddcc8a89771a8ee733819e3583",
+		"data": {
+			"inGameID": 70000026,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 958,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8585a088a1f1dd6fa2ba4a36f17bda5348339b65",
+		"data": {
+			"inGameID": 70000026,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 958,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4c9ab7f06dbedd6fcb1a30d4daea936885f7ae6d",
+		"data": {
+			"inGameID": 70000027,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 959,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6e4a3875b475dca79d64d04a645ae555c1018f75",
+		"data": {
+			"inGameID": 70000027,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 959,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bd6db9eef6ae46750a1a30a6f062b344e2101f39",
+		"data": {
+			"inGameID": 70000027,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 959,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "879bd675aea77770620e9014a6d2f79e27924a1b",
+		"data": {
+			"inGameID": 70000027,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 959,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c26ad8b0646eb6dfaae464a1a02893d83bc19a58",
+		"data": {
+			"inGameID": 70000027,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 959,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "808c32236c44fd3633f71b8c652b119284d0f7e5",
+		"data": {
+			"inGameID": 70000027,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 959,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bf44e7d85cdaa6f07b8a732f6e482aea8367eb1e",
+		"data": {
+			"inGameID": 70000028,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 960,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b5b862ec66f85424a0b90ae196661732330ae678",
+		"data": {
+			"inGameID": 70000028,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 960,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8470f35403c21cd6e86935e6b85294afe245933a",
+		"data": {
+			"inGameID": 70000028,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 960,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d172def9130d79162c39f4178fda0340e7463e5c",
+		"data": {
+			"inGameID": 70000028,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 960,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "54ae5ff8b8954e9840795b1fb29ee058a0d02b29",
+		"data": {
+			"inGameID": 70000028,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 960,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f93f8edd7c57b1b1b34882aae0f5e9d69cfcfc8f",
+		"data": {
+			"inGameID": 70000028,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 960,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1cc55796cc7e84c90b8bc69b3ba304d58a7044eb",
+		"data": {
+			"inGameID": 70000029,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 961,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "88577ba0aec404454195ee8bd303220bf2847053",
+		"data": {
+			"inGameID": 70000029,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 961,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "739c9956a40615a9aec43e0aa9ab20b6016508e4",
+		"data": {
+			"inGameID": 70000029,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 961,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c2fed91f597bf8241e99efc8b938f556867a061e",
+		"data": {
+			"inGameID": 70000029,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 961,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3626f115b422009aa617fe9509fa9eecc18bc5fb",
+		"data": {
+			"inGameID": 70000029,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 961,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a063386da4a782aca258af5ef1469dec8323f523",
+		"data": {
+			"inGameID": 70000029,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 961,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "711bf77047f4746cfc9a8e1fd6d3de629f604def",
+		"data": {
+			"inGameID": 70000030,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 962,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fb362c40b27fa0b7c24ab7120c0bac4be58a48bb",
+		"data": {
+			"inGameID": 70000030,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 962,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "85a43c4e2aa119ca488973b7d49bb432dc2a0574",
+		"data": {
+			"inGameID": 70000030,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 962,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "db804cabfc17ffff15d1e91aa1ca18e4622e6488",
+		"data": {
+			"inGameID": 70000030,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 962,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fe4696b7c8016f9623f2f79897370300417604e3",
+		"data": {
+			"inGameID": 70000030,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 962,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c152ef87709ac66fce6cb3e2c6ca80c38611838f",
+		"data": {
+			"inGameID": 70000030,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 962,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cf4194e0e8a0bc1e121675412a654e4c63c0f348",
+		"data": {
+			"inGameID": 70000033,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 963,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e3beea6dad616df1337a242ff3965aa94e7c1b38",
+		"data": {
+			"inGameID": 70000033,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 963,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5bb56ff8dc40239d34c5d0b936d4cd2048625a32",
+		"data": {
+			"inGameID": 70000033,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 963,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "facf88250d1ead97cb56115374d1a76ef0b511a1",
+		"data": {
+			"inGameID": 70000033,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 963,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b976b7b67b1dfcd639a44365ae2b77ef3d6bb6d5",
+		"data": {
+			"inGameID": 70000033,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 963,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "51a70df6e9cdd393a501744417a723b7f3d72f47",
+		"data": {
+			"inGameID": 70000033,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 963,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "612a9fa68bf24295a928c595ef99b0149eefbfae",
+		"data": {
+			"inGameID": 70000034,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 964,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "70e43b1e67f54a23ad287d9541a580b4584fc40e",
+		"data": {
+			"inGameID": 70000034,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 964,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5280da2658d5f0eab8d726ba71133ef1e09334b6",
+		"data": {
+			"inGameID": 70000034,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 964,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cd705947c7f07106ff75ee5811831f5e14e9fc30",
+		"data": {
+			"inGameID": 70000034,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 964,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "362d8e0e8e5b15a7bafbef5732c019ab926087da",
+		"data": {
+			"inGameID": 70000034,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 964,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a231f3c07def4fa6fb043a711d4fdaea54215dfb",
+		"data": {
+			"inGameID": 70000034,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 964,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f00ad854f9855d59ed0d7d94ea6829b1c5d58d40",
+		"data": {
+			"inGameID": 70000035,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 965,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e8c502634d418823c16c8c1db7443ab1576b8869",
+		"data": {
+			"inGameID": 70000035,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 965,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "288980ea84137aaa90923dbfd8cfb2a9edd5354a",
+		"data": {
+			"inGameID": 70000035,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 965,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ce5d0c6eebd6ad11dc3bb6f88f19f9f7d9b8f603",
+		"data": {
+			"inGameID": 70000035,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 965,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bb6ae092e94aa6885173563415d7620e02c64cc3",
+		"data": {
+			"inGameID": 70000035,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 965,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b575fb9e54262cd5b7dc8d3455b7fb8b8e0adb7f",
+		"data": {
+			"inGameID": 70000035,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 965,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1dcd4814db89c92719f8c7290ad9a83f1dea5790",
+		"data": {
+			"inGameID": 70000036,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 966,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "720a2408837655e95f7ec463a41d6dc69265df80",
+		"data": {
+			"inGameID": 70000036,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 966,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2ca1e367654cccbdfb0f344f36ea3258f24994b8",
+		"data": {
+			"inGameID": 70000036,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 966,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c6bc85ed32d2989f2d77b19615cf202af19375b1",
+		"data": {
+			"inGameID": 70000036,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 966,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fac4eedddb4bb3c3c20db24f08f531bf00577213",
+		"data": {
+			"inGameID": 70000036,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 966,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "00c68a98c65ccbbd341d436155ba47d5823f41ae",
+		"data": {
+			"inGameID": 70000036,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 966,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4b536f327aebd668530c679574ac2d83d922c1de",
+		"data": {
+			"inGameID": 70000056,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 967,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "86f37bfc3ba375120842b138f2d2ca269e10a03a",
+		"data": {
+			"inGameID": 70000056,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 967,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d73f60bf8d50beaf55af3f45af196cedb85a7ed6",
+		"data": {
+			"inGameID": 70000056,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 967,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8d900d985120ccf6bf5f22068ae1e623f62cc466",
+		"data": {
+			"inGameID": 70000056,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 967,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "da9454b6e2455c3ff21c7c138c2c63c51aa20e27",
+		"data": {
+			"inGameID": 70000056,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 967,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b1d2a0abaa1ca7692f7222e8f98fb008b4dc9f7f",
+		"data": {
+			"inGameID": 70000056,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 967,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8d1a7c0b24c6f8b90b8fe734dde7e74db642d1a6",
+		"data": {
+			"inGameID": 70000057,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 968,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "04063543f34dabe0b1b76f558d29ccd43f4ee58e",
+		"data": {
+			"inGameID": 70000057,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 968,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1218d2ae99839cebdd6d414016202fb9f4a699ea",
+		"data": {
+			"inGameID": 70000057,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 968,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "32e64476bd5fda51bde0d71384298ab1c86fae4d",
+		"data": {
+			"inGameID": 70000057,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 968,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "43d8181f96f9c3061f1cb86f4f0d13a164ff005d",
+		"data": {
+			"inGameID": 70000057,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 968,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0e860a12e39558b025b31380b34504213867e5f4",
+		"data": {
+			"inGameID": 70000057,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 968,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c1e62cdbec871257ddb6dd7c60f473d525a66f96",
+		"data": {
+			"inGameID": 70000058,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 969,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "907c7efab00b1ecd0a723f09c5c35a51bf418176",
+		"data": {
+			"inGameID": 70000058,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 969,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e44a5dfdcb8820c404d0f3adf08acbcb3430ddb1",
+		"data": {
+			"inGameID": 70000058,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 969,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "47f03bc401303147c5bc28cd72de3f8f31c93215",
+		"data": {
+			"inGameID": 70000058,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 969,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "487c155a0b7fa6e12933978b546f567950d5be2f",
+		"data": {
+			"inGameID": 70000058,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 969,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c15dfdce6145ad0fa7fc05d1cb0163170cb02d30",
+		"data": {
+			"inGameID": 70000058,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 969,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0db8c72d4bf563e5c5f69feea8769b4ed7409ea7",
+		"data": {
+			"inGameID": 70000059,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 970,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d3037d9e8a9fd729be5f4cbea138e1647e76bec1",
+		"data": {
+			"inGameID": 70000059,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 970,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3ee60079f3c5fba84f07d2ea0b47c4c33cf81362",
+		"data": {
+			"inGameID": 70000059,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 970,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e12ad8e66a52cf16d60b1088836bcfbd60fb5185",
+		"data": {
+			"inGameID": 70000059,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 970,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a085007e347cf5ec41c2fd19b201a08e41bf4427",
+		"data": {
+			"inGameID": 70000059,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 970,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "db482db2b53897a145d47be3b4c51e9986f97af7",
+		"data": {
+			"inGameID": 70000059,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 970,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5c256ea7130d4c37a321d79c8b898d71d95d2ddb",
+		"data": {
+			"inGameID": 70000060,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 971,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "587204370b92caa8bcb952cfa0d5263433154530",
+		"data": {
+			"inGameID": 70000060,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 971,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3460fa2023ab3a5bf52f195811073c2612f123ec",
+		"data": {
+			"inGameID": 70000060,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 971,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2f225546d1265cdfff904ceaf0646daaf75fd190",
+		"data": {
+			"inGameID": 70000060,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 971,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "aa3e50e12887e0ce13c1b5da400dc676523ce065",
+		"data": {
+			"inGameID": 70000060,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 971,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1cdf1ec69f03e9839cf8ba282922e4b8671cbff4",
+		"data": {
+			"inGameID": 70000060,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 971,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "927caa56f473f2d684e39f30760ad95d2434c355",
+		"data": {
+			"inGameID": 70000069,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 972,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2d8c69c701301d2416fd5b7bf8629b401acbc280",
+		"data": {
+			"inGameID": 70000069,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 972,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9a29b686314077719ddb31ad14862ff622523dae",
+		"data": {
+			"inGameID": 70000069,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 972,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c5428b23df5dfc8ea92379efa4228e9f42fcf353",
+		"data": {
+			"inGameID": 70000069,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 972,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a5040f0903cf6321901ff5eb44140a8d4eff49e8",
+		"data": {
+			"inGameID": 70000069,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 972,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d8c0d9792462e56d7ee497f9237b850109342bf3",
+		"data": {
+			"inGameID": 70000069,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 972,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "80ab1f7ba47c67ded9f773dd369a7a824669e086",
+		"data": {
+			"inGameID": 70000070,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 973,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "40108b7a173ff9fb8f217279a3cefcfd8ae73205",
+		"data": {
+			"inGameID": 70000070,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 973,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4c2b8f5cf43ddd69f452ce4ff255c07270ab3bcd",
+		"data": {
+			"inGameID": 70000070,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 973,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "11361a58a3c81b0d3fb158d9443ec91d4f814f9f",
+		"data": {
+			"inGameID": 70000070,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 973,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f2411a4da159772fe8da1ea7c417d0e65652c8ec",
+		"data": {
+			"inGameID": 70000070,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 973,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "16ac232038f8cb5ef334ab85fabfb862e405e964",
+		"data": {
+			"inGameID": 70000070,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 973,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "67e0673188c4ae150e7ac93d1382ea38265fd7ee",
+		"data": {
+			"inGameID": 70000071,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 974,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0a901ee95c23953f0debcf190d16e1e23a4a85f4",
+		"data": {
+			"inGameID": 70000071,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 974,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5e4b772ce8831868205cddc2e167ad1688bc57cb",
+		"data": {
+			"inGameID": 70000071,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 974,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ab48b015d59e3613b1bc6d59b05df51f71da9956",
+		"data": {
+			"inGameID": 70000071,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 974,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "534caa7f868c7928374786443f0c68aa1adda2e2",
+		"data": {
+			"inGameID": 70000071,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 974,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7e70294b76783c6a8406c11e7cf6baf61de0dc6a",
+		"data": {
+			"inGameID": 70000071,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 974,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9db1bcf81fb11b58999d1630d3d5d721f51bfe87",
+		"data": {
+			"inGameID": 70000072,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 975,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c3b215472fd797ca24415b2cfd3563aee49e1623",
+		"data": {
+			"inGameID": 70000072,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 975,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "13fcfd04989b945de212df3eae96e0cb9c9355da",
+		"data": {
+			"inGameID": 70000072,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 975,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a52d85dd1df8e97df85b9e982db4b0fc01b10bfc",
+		"data": {
+			"inGameID": 70000072,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 975,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "39cb090e13e7b0101b96dd6346a4c80b1af3cd62",
+		"data": {
+			"inGameID": 70000072,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 975,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ee5b73bd223fa8d656efd4a37582412df3f050a3",
+		"data": {
+			"inGameID": 70000072,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 975,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f209ed838a305238b4c644e690d1c996e7d855f3",
+		"data": {
+			"inGameID": 70000073,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 976,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c980172751bf4a7c6d5388c9df05517c06de9d6c",
+		"data": {
+			"inGameID": 70000073,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 976,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "37b863af2f587d6cef41cce79d58735e609dd995",
+		"data": {
+			"inGameID": 70000073,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 976,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c186b7bfca230423a7e652ac9bde14d170d22bae",
+		"data": {
+			"inGameID": 70000073,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 976,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8d4e655d6ebb7750d7e5d7d64ac2a6f476f24f9e",
+		"data": {
+			"inGameID": 70000073,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 976,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "40e8e7b06313e4193d9c41b53054ec16a8185819",
+		"data": {
+			"inGameID": 70000073,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 976,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "00e17b86cf1bdad5da21e2bc63a93b2e58cc057c",
+		"data": {
+			"inGameID": 70000079,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 977,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "063f5df72f78660c21fbc1373528b0052d144fd6",
+		"data": {
+			"inGameID": 70000079,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 977,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9aa970b78c1c534eeb61445fa0a564962085d2f9",
+		"data": {
+			"inGameID": 70000079,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 977,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8ccbc0dcba3cf5e0979b7b24f9f4d97009df21a1",
+		"data": {
+			"inGameID": 70000079,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 977,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "26ae8ddff14a12269200d0d8ca835c3cecbb8e67",
+		"data": {
+			"inGameID": 70000079,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 977,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "45adf41c7b89161c8ec5e99aab731ad7f49c1565",
+		"data": {
+			"inGameID": 70000079,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 977,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8935366546c80ea78867456967dc42a00c73035e",
+		"data": {
+			"inGameID": 70000085,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 978,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "587d22f46fb31f8748993e230ee24e2e94720662",
+		"data": {
+			"inGameID": 70000085,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 978,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4c7c7192ad974e4642118e2f7a631597312505c6",
+		"data": {
+			"inGameID": 70000085,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 978,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8e934cab1da857f95dd23418adecfca3b53ac437",
+		"data": {
+			"inGameID": 70000085,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 978,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "76963cb80b714a78471f242104f565413f153904",
+		"data": {
+			"inGameID": 70000085,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 978,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e9c5db147bae75882a7ac68c265f0d82221edff9",
+		"data": {
+			"inGameID": 70000085,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 978,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7a2d489664a693de85284335927347a5f7a6c5fd",
+		"data": {
+			"inGameID": 70000086,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 979,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2f5e2060e1b97ae27fd867c9bceee750c717a356",
+		"data": {
+			"inGameID": 70000086,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 979,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7db5b87cc5c952e6f16c33e49be41db47b7b61a5",
+		"data": {
+			"inGameID": 70000086,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 979,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a2bfed0c9ebd39c31dbfb8f1395128a0e45e3cec",
+		"data": {
+			"inGameID": 70000086,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 979,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "750737ae74867da25a39581c3b857b1316d8e2e0",
+		"data": {
+			"inGameID": 70000086,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 979,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ea926acd37fd81fc1176f81d5c792a3ead3190ff",
+		"data": {
+			"inGameID": 70000086,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 979,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "161ce045ef0a3186fc1c4ba8add7327304fefe50",
+		"data": {
+			"inGameID": 70000087,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 980,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "940cdc15c8cfe1984696da14575064083487f5b3",
+		"data": {
+			"inGameID": 70000087,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 980,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cbc78a53ecfe57f91f0f57db0f4bf31f38402a28",
+		"data": {
+			"inGameID": 70000087,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 980,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2fe83ba99fd2c000b4ce2dbda0fc15beb86fb3ef",
+		"data": {
+			"inGameID": 70000087,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 980,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "081af3e0bc234a7b6141a913fd5ac50a64b864ae",
+		"data": {
+			"inGameID": 70000087,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 980,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5a89c89896dbf526bb0a5e5bd6242a0d2b871ef7",
+		"data": {
+			"inGameID": 70000087,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 980,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "42fbccad387a2c81dd4997200ecbe5d7886b0c64",
+		"data": {
+			"inGameID": 70000088,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 981,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4f8965f67007650671f01891d7ac7b2f2a3ba3a1",
+		"data": {
+			"inGameID": 70000088,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 981,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "beb7586a1d9a3a1f29ffe24ca6af4f7e240b7d78",
+		"data": {
+			"inGameID": 70000088,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 981,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e214c27cc0bb633d69c6e16681826fcad2912af7",
+		"data": {
+			"inGameID": 70000088,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 981,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2ab85d57831c11134155892381e293a0ab55d383",
+		"data": {
+			"inGameID": 70000088,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 981,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4c625711033a7af5930c4810ebbad8b822b3f868",
+		"data": {
+			"inGameID": 70000088,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 981,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "aefef3113356e54b6e50d33676cde4d8697e8d11",
+		"data": {
+			"inGameID": 70000101,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 982,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ed4e74ee2bb0122bb2d6c2ad19041478bde1a886",
+		"data": {
+			"inGameID": 70000101,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 982,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8ac1568af85fc4cac10f1bf89f15cf5f32252cb7",
+		"data": {
+			"inGameID": 70000101,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 982,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c10e946aa97bb717f3a51c9020d066958e574662",
+		"data": {
+			"inGameID": 70000101,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 982,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5d72c73eba989f9f98c763fa4ac1cf5e4f2cbb5d",
+		"data": {
+			"inGameID": 70000101,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 982,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3d33db281a56e4ce3fb01aeacd66f59d968d8ff7",
+		"data": {
+			"inGameID": 70000101,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 982,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d007e61748afb31a0dd0aecfd569a81c1fd565f1",
+		"data": {
+			"inGameID": 70000126,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 983,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "064b6da4bc48ea41ce4d4a0fca8ac9ef54822cd1",
+		"data": {
+			"inGameID": 70000126,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 983,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "57752bc703506518e89ce2badb9f8d5cf3279447",
+		"data": {
+			"inGameID": 70000126,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 983,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6c27c80c792932306a23bf6e46daea43ee395a2f",
+		"data": {
+			"inGameID": 70000126,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 983,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2107930bccb419e5e1555681b94c318878a5d6f3",
+		"data": {
+			"inGameID": 70000126,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 983,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c61a72d3e46bfa29971bfc6b4f5bf5f3013ddf42",
+		"data": {
+			"inGameID": 70000126,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 983,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0980ba94c30e95abd2950e97532f8a41cf7655c5",
+		"data": {
+			"inGameID": 70000127,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 984,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "44e2b185938a512a2d533c29fbb91c602ccd3031",
+		"data": {
+			"inGameID": 70000127,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 984,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "95153ad786098e1599d86cc213b0013ba485e5ab",
+		"data": {
+			"inGameID": 70000127,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 984,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "71578dc4de148e57db332aac76fa7ab601c16b24",
+		"data": {
+			"inGameID": 70000127,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 984,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3aa9cde910d4dce3d3df33cb809f027924627741",
+		"data": {
+			"inGameID": 70000127,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 984,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "708b2f54f7c9315f9a56be9659ada6fe2e041541",
+		"data": {
+			"inGameID": 70000127,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 984,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8ee63e6ed3f7e0e9843cc05be4fc4791226e9da9",
+		"data": {
+			"inGameID": 70000129,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 985,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "967c27bea23ad8e27c6730fa31ef26876cc43703",
+		"data": {
+			"inGameID": 70000129,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 985,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cea53cad6a7a0d6c8a01b2bc865f3a63b04ed6c0",
+		"data": {
+			"inGameID": 70000129,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 985,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8dc2fd22f02b0b61199552ae8a3b0742e548ed46",
+		"data": {
+			"inGameID": 70000129,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 985,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cb6e0c14f2322ecf36d4091a85d65cab479571d1",
+		"data": {
+			"inGameID": 70000129,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 985,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "99fd2e494f48fa46cc0efd7366f5b3bbf7327566",
+		"data": {
+			"inGameID": 70000129,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 985,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "00b6aa7e136d0d90ccf7cfe7ddee83b68075bac4",
+		"data": {
+			"inGameID": 70000130,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 986,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "90a8292d8be44133ba6bd0c49e6349789d0c03c1",
+		"data": {
+			"inGameID": 70000130,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 986,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b2969ec6536bbf9c84a5493dd771c15796df1ef1",
+		"data": {
+			"inGameID": 70000130,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 986,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "04843f69ce9898ec565215649235dd966e58efe8",
+		"data": {
+			"inGameID": 70000130,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 986,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "27682400b587bebc51b74d502a8346426e7539a9",
+		"data": {
+			"inGameID": 70000130,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 986,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b4b517728b4766c8b381eba2a2b3882922802a01",
+		"data": {
+			"inGameID": 70000130,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 986,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ae26f5e9a17fe33ad5b5c4f7bb4ebe5888097a25",
+		"data": {
+			"inGameID": 70000131,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 987,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "716469060b715156e3ae3e1a6e27c147e782e271",
+		"data": {
+			"inGameID": 70000131,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 987,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0dec2f07d11bda91af89142e3ec9e94bfe082f21",
+		"data": {
+			"inGameID": 70000131,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 987,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "14f9d1f75680ed1da0ed123ce7862af6d5bdfe38",
+		"data": {
+			"inGameID": 70000131,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 987,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f1c078be814146bd817d1691776467baffd19240",
+		"data": {
+			"inGameID": 70000131,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 987,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d26048dbc066f6c52867f87aaff15e72841cf594",
+		"data": {
+			"inGameID": 70000131,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 987,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e75b1483b0b06cbbc1f6338cf55a5509bf65afbb",
+		"data": {
+			"inGameID": 70000132,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 988,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7acd04a39f19b38e52d5975dd87a4be251181e4e",
+		"data": {
+			"inGameID": 70000132,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 988,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d4455db3840617a9a9be9d505ddb2cc03bf548a3",
+		"data": {
+			"inGameID": 70000132,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 988,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "77854382dd34b2e130ebf915ad6d2e57f895f399",
+		"data": {
+			"inGameID": 70000132,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 988,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5ca3320dd1a48c93ad08f900daf566968612b35a",
+		"data": {
+			"inGameID": 70000132,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 988,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3c9f079eaad636ddb269a9ddb1b8bc55f127d305",
+		"data": {
+			"inGameID": 70000132,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 988,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "662df756a86302dad9f619ee5dbc42000cb482cf",
+		"data": {
+			"inGameID": 70000148,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 989,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6f4b1b4b1342da9caa98f0d7441b258359422f89",
+		"data": {
+			"inGameID": 70000148,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 989,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f35be77a1049570ac2f125ec3ebfc8c562cd559c",
+		"data": {
+			"inGameID": 70000148,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 989,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b4195766fbb4ff363e62cf25f0d77053cbf2262b",
+		"data": {
+			"inGameID": 70000148,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 989,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "99de23bebfe69b458d5e576b9d8841134b39a38c",
+		"data": {
+			"inGameID": 70000148,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 989,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0a4bcda573dd5d4583984928b5893947c65ecc2d",
+		"data": {
+			"inGameID": 70000148,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 989,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "78ba4aaf486e00895a39de62ac405d555d302921",
+		"data": {
+			"inGameID": 70000149,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 990,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a48a608a126195d794660ddd6ba510d0b8f225f8",
+		"data": {
+			"inGameID": 70000149,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 990,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6970af8d491502321af65de814374f5f0892300d",
+		"data": {
+			"inGameID": 70000149,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 990,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4d09ad705c07a5c0b882b408a58c850310752053",
+		"data": {
+			"inGameID": 70000149,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 990,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c35eb8f384e89e3e8b25b817bc43a9cc253e3e3f",
+		"data": {
+			"inGameID": 70000149,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 990,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cbe9457e1772f9485e7fcc4a1cd771dab5aeb874",
+		"data": {
+			"inGameID": 70000149,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 990,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b7a2c84377def6d5ffbb8c0375bce32f300eeff8",
+		"data": {
+			"inGameID": 70000155,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 991,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d3363c877146057ce1baf0bc5f83fe9406c7ba1f",
+		"data": {
+			"inGameID": 70000155,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 991,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "01e3820a8fd5f6e84f0cde390dd733805a6c83fb",
+		"data": {
+			"inGameID": 70000155,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 991,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "067aed508d03c07b1d96c54f3149f4678d31e219",
+		"data": {
+			"inGameID": 70000155,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 991,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "eb6b1fc1bfb3a43a865c08f89852bc5dca6f2088",
+		"data": {
+			"inGameID": 70000155,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 991,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c3c9e8c04f30d540cf49e99017d2fb87bb37d952",
+		"data": {
+			"inGameID": 70000155,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 991,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b85ba87463725fb2d383003bbfd76c2cfb3970bb",
+		"data": {
+			"inGameID": 70000156,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 992,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0eb092122808422aead90fea15ba1e7e64ea6ad2",
+		"data": {
+			"inGameID": 70000156,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 992,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "35011e4e56fa79ce5921b9f82b91dc7693cf0496",
+		"data": {
+			"inGameID": 70000156,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 992,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "916ff3f25e14fb24c3da3b22e535e5b04e05319b",
+		"data": {
+			"inGameID": 70000156,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 992,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "95455fa114ae4e361e38833afa77f3cf37c6e1ff",
+		"data": {
+			"inGameID": 70000156,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 992,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bcced314fa3f352177b56c1b1d5b5f80a6925cba",
+		"data": {
+			"inGameID": 70000156,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 992,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bf0277d5af3938df2626aee199f6181dc9eb710f",
+		"data": {
+			"inGameID": 70000157,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 993,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "25f7e93039e61d5ef8c6c674250bbdd46b8571e3",
+		"data": {
+			"inGameID": 70000157,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 993,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c5b5de682d0d2fe8ee3e86389e4ecadf91c1f7e8",
+		"data": {
+			"inGameID": 70000157,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 993,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "016b8964084123a4784c69dce868b4104a2fbbe5",
+		"data": {
+			"inGameID": 70000157,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 993,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c169e72f39850884d701787d557e3d838a7555a2",
+		"data": {
+			"inGameID": 70000157,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 993,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "84ce2ed3d151d283706a49ca2863ce55da515d6d",
+		"data": {
+			"inGameID": 70000157,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 993,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bc98931b3e8e8f40851632ccacc6f291eab90c69",
+		"data": {
+			"inGameID": 70000183,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 994,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0b6fc4a2de50d88d14a8b4ba5b2cff748246869d",
+		"data": {
+			"inGameID": 70000183,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 994,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e1c0ff4436f7c1becc3ce9a45d564ae001784b96",
+		"data": {
+			"inGameID": 70000183,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 994,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "955e78668a9514eef2916f4cba94dac3793feb00",
+		"data": {
+			"inGameID": 70000183,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 994,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "63cf7c631e251eba13f4a80c50d0a5cde0c497bf",
+		"data": {
+			"inGameID": 70000183,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 994,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e7de829a0e56ec57a5527bf758348ec7a73238f2",
+		"data": {
+			"inGameID": 70000183,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 994,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3e2128c1c5d39b8e733815bb1e6adb6ef4015d98",
+		"data": {
+			"inGameID": 80000016,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 995,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "05230480533eb8b351ce71a37c100c3043a0cadd",
+		"data": {
+			"inGameID": 80000016,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 995,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2372d3e4fe73813fd241305f5dad2d547638de18",
+		"data": {
+			"inGameID": 80000016,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 995,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d024a7807063a654b4ad8277446e65fac447a706",
+		"data": {
+			"inGameID": 80000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 995,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e1401d7b167cc371862eb43e85d0b979231fa7ee",
+		"data": {
+			"inGameID": 80000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 995,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5c3ac16aee64d35a15bdfeaf5d55c81dfa1391e7",
+		"data": {
+			"inGameID": 80000016,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 995,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "abd499bfee1aaee6e1671998349fea2a15dc69d4",
+		"data": {
+			"inGameID": 80000017,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 996,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "74fb11b7e0c4eb636ed28f19bcb5271ac71440e3",
+		"data": {
+			"inGameID": 80000017,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 996,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3dda66b0fa087d99a5609b79c839b8c7f96f9044",
+		"data": {
+			"inGameID": 80000017,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 996,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "86918630e058acb7efae1cb3e2d8151b0a18a638",
+		"data": {
+			"inGameID": 80000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 996,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5a383ffb61d8fe822ae18876bcf4a0f4fd67136c",
+		"data": {
+			"inGameID": 80000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 996,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "84d012fa3b55bc863e614cd31047e5bf8ddf0066",
+		"data": {
+			"inGameID": 80000017,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 996,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c896daca9f010632dfa95dec34e5c759bf74696f",
+		"data": {
+			"inGameID": 80000018,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 997,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2d1b31f8b755e97e71550f9bce296d0cc8ef5eb2",
+		"data": {
+			"inGameID": 80000018,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 997,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "00573a86767d6517025129b491dbc4f062270293",
+		"data": {
+			"inGameID": 80000018,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 997,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "91f61e9d48c72dea3c26c892ba9f5b9dcad5708a",
+		"data": {
+			"inGameID": 80000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 997,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "668d9b63a691dc634903f5a5ba4eac8ecefdef70",
+		"data": {
+			"inGameID": 80000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 997,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0cd11e01e25352470b624b1ef194f437d6dd6ab6",
+		"data": {
+			"inGameID": 80000018,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 997,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8566f431629992dfff2c4dfe80a724d5648740b6",
+		"data": {
+			"inGameID": 80000019,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 998,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7c2d878ad2c73cc7bf5d86381bcc35bb95e6a87e",
+		"data": {
+			"inGameID": 80000019,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 998,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b4a486e7ad25b22c1b9eccb5d96d7543c2db7f06",
+		"data": {
+			"inGameID": 80000019,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 998,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4e1e2add1f33f8e06df4785acee7b34f0e8947d8",
+		"data": {
+			"inGameID": 80000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 998,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7dfa857cbe896f485295deef8d3ef02de91fc51b",
+		"data": {
+			"inGameID": 80000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 998,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "95232802934c4772b09d2b6d2771aec2783d59ea",
+		"data": {
+			"inGameID": 80000019,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 998,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7811f9d363e2490148515d289bb315695dcf6ac9",
+		"data": {
+			"inGameID": 80000020,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 999,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "04a599e86d350413db377d627046b0f1f2fddcf1",
+		"data": {
+			"inGameID": 80000020,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 999,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4b0adf2005442bdd7b933cbc34d991eb6ffe263c",
+		"data": {
+			"inGameID": 80000020,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 999,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "706ae1d04be2303a9c11757550f3e493d84316b7",
+		"data": {
+			"inGameID": 80000020,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 999,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "02a4fd2e7c2e24d09afb6fcaac1238ac48a06c73",
+		"data": {
+			"inGameID": 80000020,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 999,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "544d70a08c00c0b9f2a94af4257339965e60239e",
+		"data": {
+			"inGameID": 80000020,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 999,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b819123409ad8fa3f044c98c768b8b0414f99d44",
+		"data": {
+			"inGameID": 80000032,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1000,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "22929bbc0fae726514bb78e880e631cc839712df",
+		"data": {
+			"inGameID": 80000032,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1000,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fa25079c4b963e8f8645305f0a91b918f9cb71ad",
+		"data": {
+			"inGameID": 80000032,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1000,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "73c5f1743f762a7d1ef7c2208dcddd7524c1053b",
+		"data": {
+			"inGameID": 80000032,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1000,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "346a43f33fc4549c505b930372b581c2afd1c351",
+		"data": {
+			"inGameID": 80000032,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "1",
+		"levelNum": 1,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1000,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9803257afe76877d78aa91384b7ade3c6a7336ec",
+		"data": {
+			"inGameID": 80000032,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1000,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "21dd536e0403cd73d3c78579d8c5235678e06b56",
+		"data": {
+			"inGameID": 80000033,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1001,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "184038c730fbed5dd77c0cffa53c52f454384d4f",
+		"data": {
+			"inGameID": 80000033,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1001,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7c0cb8760b5fdd264255ec338aa1ba3281a82559",
+		"data": {
+			"inGameID": 80000033,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1001,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e896db97e0e9d279107f26b19f809b5e1fa78000",
+		"data": {
+			"inGameID": 80000033,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1001,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "42b80788eed4766fb97d25b2037cebfee05ebfbe",
+		"data": {
+			"inGameID": 80000033,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1001,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8125f153f3715f7b372347f9fbfb13d0154e0779",
+		"data": {
+			"inGameID": 80000033,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1001,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cd7a5a7a88b5cd7021789b6fcf16db24595d64e9",
+		"data": {
+			"inGameID": 80000034,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1002,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1e120559083f1ec67d0f6b7c763dbf9a66ad59e3",
+		"data": {
+			"inGameID": 80000034,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1002,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b18e1cb2c0cf097d50a049a48dff1b28b3132bf2",
+		"data": {
+			"inGameID": 80000034,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1002,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e99eaab265a4c1f9241724ac3c7ade59765ba3e5",
+		"data": {
+			"inGameID": 80000034,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1002,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b1e1bad4279f3a30440dac82d23152b3bc3c6b8f",
+		"data": {
+			"inGameID": 80000034,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1002,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bd6e851d92e397b580e9ab385aa0b19d7aa95a1a",
+		"data": {
+			"inGameID": 80000034,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1002,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3e27c1e189985bc81eaf730017d4d8903ad445ee",
+		"data": {
+			"inGameID": 80000036,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1003,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b7d263a45762f86de47b71d06a942112853e695f",
+		"data": {
+			"inGameID": 80000036,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1003,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e4cd232dd86d64bfdf515d94d70b79a00a990209",
+		"data": {
+			"inGameID": 80000036,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1003,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f96ef88bd74c73fdb727520db75a3e4c6be5ced3",
+		"data": {
+			"inGameID": 80000036,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1003,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b33a09e203bf0045142e3012fcda3052b83907d9",
+		"data": {
+			"inGameID": 80000036,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1003,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4fda931e051fce80b9e90d7de318005ffedcbe4e",
+		"data": {
+			"inGameID": 80000036,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1003,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cf06768ff9e754840af9b3756a8802ee301168c8",
+		"data": {
+			"inGameID": 80000302,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1004,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "937ddf0689be1fca488a20660c6e411ff3f2e6d7",
+		"data": {
+			"inGameID": 80000302,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1004,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "664fee168985b761055932ea3a7087abb229bfd4",
+		"data": {
+			"inGameID": 80000302,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1004,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2c3e6af46733b44eabbb47371972928d567f48df",
+		"data": {
+			"inGameID": 80000302,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1004,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2dfbe958130f638a04b1accb5ef1cedea69506ca",
+		"data": {
+			"inGameID": 80000302,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1004,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "474667409b776a649939595d3a582a33e9c4990f",
+		"data": {
+			"inGameID": 80000302,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1004,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e608d70dbbd2a6397298fd9fffe1ee4a80710666",
+		"data": {
+			"inGameID": 80000303,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1005,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b1b58faa65911807e2bed912a938e358eb3a87a4",
+		"data": {
+			"inGameID": 80000303,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1005,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5c21e58d68f380d0746c2e2b8939740687016aa4",
+		"data": {
+			"inGameID": 80000303,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1005,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f6e70e31f9e61f6299243d4f2821f9a236817c8a",
+		"data": {
+			"inGameID": 80000303,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1005,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1abfa023fc21c9d2c3515c1f08f889e7dfb1cd43",
+		"data": {
+			"inGameID": 80000303,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1005,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9266c0fed0b932631239db9f1a5df0a4f6fa67ed",
+		"data": {
+			"inGameID": 80000303,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1005,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e3b0ba0445afdaed5979c65e4045fd6d3c33ce23",
+		"data": {
+			"inGameID": 80000304,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1006,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "92a85620507d15f2134b89d879851adb2940e687",
+		"data": {
+			"inGameID": 80000304,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1006,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "760648c13ec5c83b58da46ec07e414cd46a18885",
+		"data": {
+			"inGameID": 80000304,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1006,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c5f735c6cd78ac217e2dab3936651200ad8dbee2",
+		"data": {
+			"inGameID": 80000304,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1006,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "56f5afb834e300c6d9b8b15430a01fbaf423054b",
+		"data": {
+			"inGameID": 80000304,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1006,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d478deaa7d020ab3be9a63fa70ff95f96ee34102",
+		"data": {
+			"inGameID": 80000304,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1006,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d0c36f93b7e7fc6b611d7446f9bc5644f8ef7b20",
+		"data": {
+			"inGameID": 80000305,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1007,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "368c2df9475d32d7b02fef20e21a438c24fe65ef",
+		"data": {
+			"inGameID": 80000305,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1007,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1d5a24134418a62d74822e683b2d831250708b35",
+		"data": {
+			"inGameID": 80000305,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1007,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3ac96f40ea49b6b0e8836b8f9e32e91a968e0cd8",
+		"data": {
+			"inGameID": 80000305,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1007,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8e71ce09cb60aa7a5480ea241bf4b99fd447e6c6",
+		"data": {
+			"inGameID": 80000305,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1007,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "73030cb4538923844f305e5b20326917f01fcfdb",
+		"data": {
+			"inGameID": 80000305,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1007,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "124f1476b83ef85db1e18071dedf0d9a594ed251",
+		"data": {
+			"inGameID": 80000306,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1008,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "49780e8449b06d8437472e9d928e8dbfe8f5d2e6",
+		"data": {
+			"inGameID": 80000306,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1008,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "43c89c07c067273e26e81a0df99fc4bc31a39916",
+		"data": {
+			"inGameID": 80000306,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1008,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0df284dd9dc270234b0e26138987f80ed22ee7ac",
+		"data": {
+			"inGameID": 80000306,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1008,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2d1602d159ad9adee53ab8b0204a6b3cbd0238eb",
+		"data": {
+			"inGameID": 80000306,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1008,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ac2c7e4471e32960054d14430e8339dc2b22dd19",
+		"data": {
+			"inGameID": 80000306,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1008,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b9ae15691e6b553aa1cf71f7aed1af11b1875078",
+		"data": {
+			"inGameID": 80000307,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1009,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "69c04faf551cec06e3c6474f41fc9c21a7598aa7",
+		"data": {
+			"inGameID": 80000307,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1009,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c0651733fb8f24671713bfa3caea742e91ff57d0",
+		"data": {
+			"inGameID": 80000307,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1009,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "924921ef90e099ea5e1f61d58fb728586f6c5513",
+		"data": {
+			"inGameID": 80000307,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1009,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dfd6d498808045aec50ac1f8e7c73be6e486d615",
+		"data": {
+			"inGameID": 80000307,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1009,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "21d6b94e6e39bc6af124e012dfaf23f811999162",
+		"data": {
+			"inGameID": 80000307,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1009,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "61ba6170b0e948b91d872e78623235ce77f7035c",
+		"data": {
+			"inGameID": 80000308,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1010,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9aa889d3288395873723ae3a9a1fcd24eaa76807",
+		"data": {
+			"inGameID": 80000308,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1010,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a3f1f08cbe13416242c7835bd92b98525b9234bb",
+		"data": {
+			"inGameID": 80000308,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1010,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "459813c18a1b40b5c3dd4a0e4d04ddc5d681d131",
+		"data": {
+			"inGameID": 80000308,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1010,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "11385e20f01436cd3a270ca3abcc96bdd80dd572",
+		"data": {
+			"inGameID": 80000308,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1010,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cf48cee1af46fe41e37b9016986e5553a167cd23",
+		"data": {
+			"inGameID": 80000308,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1010,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "46e7be62502a4009c157b3ffdf14eef7d2ae0936",
+		"data": {
+			"inGameID": 80000309,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1011,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c8f5ffd00748a965014db14746f1ebdff74fe42f",
+		"data": {
+			"inGameID": 80000309,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1011,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9bdecb19bb67066eaa6649eed18e439cfef5d5ac",
+		"data": {
+			"inGameID": 80000309,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1011,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "42c0cdec14fbce7dba7c567dbf3c6041b67d7a31",
+		"data": {
+			"inGameID": 80000309,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1011,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "491d8f3455e0e47698ed1aae1f568f48546af86d",
+		"data": {
+			"inGameID": 80000309,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1011,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cc2e10d79f049d16a2f7c10f57e9ae040c9cdfef",
+		"data": {
+			"inGameID": 80000309,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1011,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3a81decef367187f3b9aa13ba48c646f04e4faee",
+		"data": {
+			"inGameID": 80000310,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1012,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "78dd8cebc17fc396f53343e23cf884221da0e501",
+		"data": {
+			"inGameID": 80000310,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1012,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d25d0ace885359253c467b5aa81e55e6c6d9f6e1",
+		"data": {
+			"inGameID": 80000310,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1012,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5ce40b30bea40d08024a434ae5d3e17fe40e3252",
+		"data": {
+			"inGameID": 80000310,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1012,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "43a6820806ad3274c52df5f29e3720487f26ad9c",
+		"data": {
+			"inGameID": 80000310,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1012,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d4fef223e46d27dbd3700497e034556e44afb219",
+		"data": {
+			"inGameID": 80000310,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1012,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0b321e021d6a781141d093d48e757eeecc0c8137",
+		"data": {
+			"inGameID": 80000311,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1013,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "928f1d60e38b627a8fb827a138a354ccb917a1c3",
+		"data": {
+			"inGameID": 80000311,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1013,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "00144ffac040dc8674231af964e9728f9fc249c5",
+		"data": {
+			"inGameID": 80000311,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1013,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6e05564e58a4a7b20b86e7dcbc1daca6e79b3d51",
+		"data": {
+			"inGameID": 80000311,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1013,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "630184a5ccae127195fe1f6de1a13e4fc3593874",
+		"data": {
+			"inGameID": 80000311,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1013,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4d9eebb0ff3a18d10ba5e46ec906c51c5a5f304d",
+		"data": {
+			"inGameID": 80000311,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1013,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "944bad90b7b89e11db7147455bb982c74c3f731b",
+		"data": {
+			"inGameID": 80000312,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1014,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bc178a5befe1e49df726e1653cca3734f4e73340",
+		"data": {
+			"inGameID": 80000312,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1014,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "033fbff9a777c951a633f1b35644daa5a0ff7767",
+		"data": {
+			"inGameID": 80000312,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1014,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5b319ba33ccdc27ac3387a9b0668cf80aba2017d",
+		"data": {
+			"inGameID": 80000312,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1014,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cadd01dea49cd5ed3df101c382e7b7536b6ebc4c",
+		"data": {
+			"inGameID": 80000312,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1014,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4e6e973ef1b2e34803e41746018f02c27a35fcc9",
+		"data": {
+			"inGameID": 80000312,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1014,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "facdc94d37f8d67a56bd028ebc716cc7fdab077f",
+		"data": {
+			"inGameID": 80000313,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1015,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ce2f0013e0f706725eeb2419baf1eda590b1d484",
+		"data": {
+			"inGameID": 80000313,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1015,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dc337eb6df39fb2dbc07913c91ac773e434a2a7f",
+		"data": {
+			"inGameID": 80000313,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1015,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2262fa38cdac946d7cd0bc4f290c3ea7ab9fc8c1",
+		"data": {
+			"inGameID": 80000313,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1015,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b41a97c81791526f071fcde3c684ddbd14aeb113",
+		"data": {
+			"inGameID": 80000313,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1015,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f3350f69ffb1dc120710988477e895f7ac450e57",
+		"data": {
+			"inGameID": 80000313,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1015,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "52c108ca6dac2c66796e65520064c159d8edeab8",
+		"data": {
+			"inGameID": 80000314,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1016,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dc159cd7be17ae8b2c3b94c8fd0e88064128639b",
+		"data": {
+			"inGameID": 80000314,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1016,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4c2fa538633883b5dca40571ec1002054a02cdf4",
+		"data": {
+			"inGameID": 80000314,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1016,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6025ac5c1efd6d6e074f29ef9dc839571d190603",
+		"data": {
+			"inGameID": 80000314,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1016,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4aaf4288815a5a1262c1ab205a9cecd985689581",
+		"data": {
+			"inGameID": 80000314,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1016,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9149c930c7384f5833b6f5b5c8fa86e74c983f35",
+		"data": {
+			"inGameID": 80000314,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1016,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c6999bd7611f207b68ff772c16f8145ce0cb58b6",
+		"data": {
+			"inGameID": 80000315,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1017,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f86751665f85cf4d87b1221548a7a0a3b333106f",
+		"data": {
+			"inGameID": 80000315,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1017,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b48efcd029098d2ab9b0d9cb144c6028403bc149",
+		"data": {
+			"inGameID": 80000315,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1017,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "18714ada6889f2d7636bf699d0eda324b545d786",
+		"data": {
+			"inGameID": 80000315,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1017,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7a92cf00b5a0d62ee7adf4ec69435241eff42ea5",
+		"data": {
+			"inGameID": 80000315,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1017,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f4a0b9c57c5a10b8faf174f570c226b526a196ad",
+		"data": {
+			"inGameID": 80000315,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1017,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "eda2382d62a0bd860b4dc30b3e0ef0072c946696",
+		"data": {
+			"inGameID": 80000316,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1018,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fe0928afc549b275d9d85c092d687c13ff8f2593",
+		"data": {
+			"inGameID": 80000316,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1018,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c6da5dba81a6bbe05e4cc9bfd87a1f0258aa7b54",
+		"data": {
+			"inGameID": 80000316,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1018,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f0b477a0017c12b1c4f5b16487e524ef0b121bb7",
+		"data": {
+			"inGameID": 80000316,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1018,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f51b162ef973f814a8b86cefb6bcd56e4c1a69cd",
+		"data": {
+			"inGameID": 80000316,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1018,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1e07878e515a6e85baa09d2ee037a27d9c90a8a0",
+		"data": {
+			"inGameID": 80000316,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1018,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d9236821929e06809ee8f6850515dabf2468983e",
+		"data": {
+			"inGameID": 80000317,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1019,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ce3134ab0bbbc976eaecd2ebc725e2e66852587d",
+		"data": {
+			"inGameID": 80000317,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1019,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bec916593aa119d8de10c99c631c86d11234302c",
+		"data": {
+			"inGameID": 80000317,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1019,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f05fe5c8da13ea9cc075f9b520f1d5d98d248932",
+		"data": {
+			"inGameID": 80000317,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1019,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e87c49c8add7c373a86a706a6a7f87ddda9026ba",
+		"data": {
+			"inGameID": 80000317,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1019,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7c02205809f9b4fd8e9f790f2724a298cb8c90a6",
+		"data": {
+			"inGameID": 80000317,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1019,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bd67db86bd9d00bd05190b101d3c9b4cb16c43b1",
+		"data": {
+			"inGameID": 80000318,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1020,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b2827eaaaa397c331f1f2493044717400032aac3",
+		"data": {
+			"inGameID": 80000318,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1020,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "04f6e6d482025691c71c8c190d54ca84b60a2e3f",
+		"data": {
+			"inGameID": 80000318,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1020,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fa7b30b95272f9abc78e3c7e3e3cbd8416cefeee",
+		"data": {
+			"inGameID": 80000318,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1020,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2e5d61bcb8a28b4c493244711521fb5fa5d059a7",
+		"data": {
+			"inGameID": 80000318,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1020,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d3de4a6b1d738184fc340b8d843544a62d1a66d0",
+		"data": {
+			"inGameID": 80000318,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1020,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bb8482843bc1c5fbb0ad29e7d87e0374378089f4",
+		"data": {
+			"inGameID": 80000319,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1021,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7383ac11227c933d9535d2f0e2451c497ff06414",
+		"data": {
+			"inGameID": 80000319,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1021,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ab3ef0c54e3c573866670bf7c8cfa928114bc72e",
+		"data": {
+			"inGameID": 80000319,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1021,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3a399007f62c74f57955531f9b1711087d7e04df",
+		"data": {
+			"inGameID": 80000319,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1021,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f7045a9e331c4a350956e1ec642c15b873fbd906",
+		"data": {
+			"inGameID": 80000319,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1021,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e59137043c377113e6043330742b9c4e3433f05a",
+		"data": {
+			"inGameID": 80000319,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1021,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c48f2061fe34c00d111883e4d45f96fb1623f821",
+		"data": {
+			"inGameID": 80000320,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1022,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "72bd09081fcfa0e96c42c9d6ed733271ddf8ef01",
+		"data": {
+			"inGameID": 80000320,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1022,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "126029d18b0ee55a17789eed76edab56fb798d5d",
+		"data": {
+			"inGameID": 80000320,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1022,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "178989af1e3abef9135e4ea344c5f834e3524c40",
+		"data": {
+			"inGameID": 80000320,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1022,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a0dc822b1743c8959344fac986639e94075d95a4",
+		"data": {
+			"inGameID": 80000320,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1022,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b1f6c8719703ddde0b0a1d7348497b792ce537c9",
+		"data": {
+			"inGameID": 80000320,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1022,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "458a9f9575c68364b8b973efc5dbed9cda454f74",
+		"data": {
+			"inGameID": 80000321,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1023,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0a519c89647d69b19fdc4c46c8ced23b2273c5f2",
+		"data": {
+			"inGameID": 80000321,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1023,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ee7410266d4f29d486180fe4727344838e7b3b07",
+		"data": {
+			"inGameID": 80000321,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1023,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "85c63ea005dcada0b43dd21baf2627b8000eeaeb",
+		"data": {
+			"inGameID": 80000321,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1023,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "51087146e6eaf242b7e84bc7eeb2c534f00ef0d0",
+		"data": {
+			"inGameID": 80000321,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1023,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "29c51789465d11b72a90304f8036ebc7d7e94629",
+		"data": {
+			"inGameID": 80000321,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1023,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ce9a2d866ace1964b523bd900c955c92461e4825",
+		"data": {
+			"inGameID": 80000322,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1024,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9958c0cc701c187b4b781e21783fd0707006989a",
+		"data": {
+			"inGameID": 80000322,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1024,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "80d3d88ba30cbf7c29d77a751aadd4589acca58f",
+		"data": {
+			"inGameID": 80000322,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1024,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "34028c7c26b81feac2e89eda49159325ffe713a5",
+		"data": {
+			"inGameID": 80000322,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1024,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2388d890b2e85642638921c9b0d01a34a685c1b7",
+		"data": {
+			"inGameID": 80000322,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1024,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b425ab08c5446b7cf6f04b0454d43659e816633b",
+		"data": {
+			"inGameID": 80000322,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1024,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ae8536a8a8001e3623f4963746b1923c4b701958",
+		"data": {
+			"inGameID": 80000323,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1025,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a3983d7a9e48b688955497773c9ca252aeaff8fd",
+		"data": {
+			"inGameID": 80000323,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1025,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "10a486a22bef4db6f74605acc6388b8eb06e12b4",
+		"data": {
+			"inGameID": 80000323,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1025,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "21e54b046f10f99f600cc5a161922b56936a1fc7",
+		"data": {
+			"inGameID": 80000323,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1025,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bf29217b2f752a0a365ac49c70782520766aed4d",
+		"data": {
+			"inGameID": 80000323,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1025,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ec8c9b832c781549d684fa14b4cf7ce56fe95f31",
+		"data": {
+			"inGameID": 80000323,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1025,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cfce7dddf0e5783464943a8adc83113a75bc143d",
+		"data": {
+			"inGameID": 80000324,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1026,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8d8aa0028c8334e797471eaf62762c864d1d93c2",
+		"data": {
+			"inGameID": 80000324,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1026,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "188bafecaa07c49246537a8a31a7b88c6921f69b",
+		"data": {
+			"inGameID": 80000324,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1026,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e9ebac07b63be0d7cd863a8608e280481c1eac57",
+		"data": {
+			"inGameID": 80000324,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1026,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2094f06e19120245702a43e668435fe8dcf7cbaa",
+		"data": {
+			"inGameID": 80000324,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1026,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8f5ae327a86c48889499640eca3daa18b0dcb04f",
+		"data": {
+			"inGameID": 80000324,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1026,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "aa590f57de0f633f926b5a03789805ea37f5054a",
+		"data": {
+			"inGameID": 80000325,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1027,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3bdb30b44bd569932646d1d7482873db812074e3",
+		"data": {
+			"inGameID": 80000325,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1027,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2678be29e84273eaba21fa698a367d788905fa7d",
+		"data": {
+			"inGameID": 80000325,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1027,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "80929c95da95e85830536281a359f315100c62f5",
+		"data": {
+			"inGameID": 80000325,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1027,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e66dabe13573eb445fe92e7c5f4e5ec028788d9a",
+		"data": {
+			"inGameID": 80000325,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1027,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4d06b899d00a51ce0d17a80bb2203ce1e12317a7",
+		"data": {
+			"inGameID": 80000325,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1027,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0b6f035027a8813871b5d9a4e7c4b6457d904214",
+		"data": {
+			"inGameID": 80000326,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1028,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dbf4bd0ac25fce12a820b98e3682a74c07f9d6e0",
+		"data": {
+			"inGameID": 80000326,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1028,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8cabe8306dc407181d2df0650bfca27eb9d63dfa",
+		"data": {
+			"inGameID": 80000326,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1028,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "aa29417fa23e15027698d15448df1234a18172cf",
+		"data": {
+			"inGameID": 80000326,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1028,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9816e2f3ac65db13d6b3692d74f3a88cfab30c28",
+		"data": {
+			"inGameID": 80000326,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1028,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dd6283465152fc93bdf4b465ea2ea53ae1b1f264",
+		"data": {
+			"inGameID": 80000326,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1028,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "59e9db34959550d64505759fc1b6339353b5ad4d",
+		"data": {
+			"inGameID": 80000327,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1029,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "78689a156555e1afc621f67dfffbbb5ea950b548",
+		"data": {
+			"inGameID": 80000327,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1029,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e9426ac1a4076027a8563d4189e645a961743f7e",
+		"data": {
+			"inGameID": 80000327,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1029,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2c6e7f5b233dfca832c4ecacbf51c3520e80efd2",
+		"data": {
+			"inGameID": 80000327,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1029,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0f2b9aaeba9387b8276891527dd85df936393053",
+		"data": {
+			"inGameID": 80000327,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1029,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7ff00ed368e71b496bedd097966f84a3ed97a6b6",
+		"data": {
+			"inGameID": 80000327,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1029,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "edab2fe0d31695b2ba71175c8315035040097536",
+		"data": {
+			"inGameID": 80000328,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1030,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9311177c5cfd2c60a6184df7121bef23ae25c9ae",
+		"data": {
+			"inGameID": 80000328,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1030,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "918091f357fe21b0ec6042003b6483ee87940a19",
+		"data": {
+			"inGameID": 80000328,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1030,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1c10ce265350546947150b826be90d1edc157199",
+		"data": {
+			"inGameID": 80000328,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1030,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "66bcf05c0491efd1404f2906ebe42226e000f7ab",
+		"data": {
+			"inGameID": 80000328,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1030,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "73902e908510a30698fe9181a3638ee62742199b",
+		"data": {
+			"inGameID": 80000328,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1030,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5e23064b62d5d65c89991b4904416da546f68197",
+		"data": {
+			"inGameID": 80000329,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1031,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b01bb55a57b79c825ec3478ad985b1f1ad781aa8",
+		"data": {
+			"inGameID": 80000329,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1031,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "779e954f644f2785c1f678aa8a6c7f515d2dda00",
+		"data": {
+			"inGameID": 80000329,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1031,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f0895892c3064ce9b1c68a8df8efb9c532de17f2",
+		"data": {
+			"inGameID": 80000329,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1031,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f25e27146bc18b46497585519f9de5be5c8430de",
+		"data": {
+			"inGameID": 80000329,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1031,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "cd26709bca97c80d164f8e2da5a94ea33c68d1ec",
+		"data": {
+			"inGameID": 80000329,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1031,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d5164ce83db5cba76435057617326878f3831e59",
+		"data": {
+			"inGameID": 80000330,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1032,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "42f0f56d0c15ba62863f447c7c08b4a498436b43",
+		"data": {
+			"inGameID": 80000330,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1032,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "db96813a4d892c0e9cc72c06e3f1adc5500c56a6",
+		"data": {
+			"inGameID": 80000330,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1032,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "05cf3ef511078e13d39f4b4e55e1f2f73592a7ed",
+		"data": {
+			"inGameID": 80000330,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1032,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "664ff019065c6993a33f73e7ec6f1dccbaaba74b",
+		"data": {
+			"inGameID": 80000330,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1032,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d026bd21def7fc4463dbea60ea77e50c6ad94038",
+		"data": {
+			"inGameID": 80000330,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1032,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d2c6bfa1941de09c284ea8f3e6b79164f6867bd2",
+		"data": {
+			"inGameID": 80000331,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1033,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a1242283ad826982c3480396df3ad56cb2fcabab",
+		"data": {
+			"inGameID": 80000331,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1033,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "65df0d5b49b81f86c7f311e390dd4636769daa03",
+		"data": {
+			"inGameID": 80000331,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1033,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8f164020e1dccb42ca2f337dad0410b2aae70b0a",
+		"data": {
+			"inGameID": 80000331,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1033,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c8d22afb363173b33cbf074a537e2f4fa08e55b7",
+		"data": {
+			"inGameID": 80000331,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1033,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "00882ca2729d7023295c6449fa39b2739e4c4434",
+		"data": {
+			"inGameID": 80000331,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1033,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "552410eb9a442b2c755ad2129a4b62ec71db9d56",
+		"data": {
+			"inGameID": 80000332,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1034,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "eda754a0df69f025ab24c9459edee2cef934a4f1",
+		"data": {
+			"inGameID": 80000332,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1034,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "04451726ed0bd05bc1093577b1042c332eaae2e9",
+		"data": {
+			"inGameID": 80000332,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1034,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "96e91570ebf1c8eb93321684fd808f5f1f684bfa",
+		"data": {
+			"inGameID": 80000332,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1034,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6932b781da91805d555c34aa6ccdc3a0b8c38811",
+		"data": {
+			"inGameID": 80000332,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1034,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a4ce456fb0ae14b8e72a842572ea0850462c7508",
+		"data": {
+			"inGameID": 80000332,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1034,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "441d9f140510514c9beb375493067857090adf0e",
+		"data": {
+			"inGameID": 80000333,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1035,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c2526e95468ce71a7656bd5ff59293f2e8e9c376",
+		"data": {
+			"inGameID": 80000333,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1035,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4e1f86b2c36bce136c463864e0bfb3e7825e636d",
+		"data": {
+			"inGameID": 80000333,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1035,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "479c98ccd38f165581432ef6406bd150ba0b0e2a",
+		"data": {
+			"inGameID": 80000333,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1035,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7ffa27259c3b675b2d7637f15c5683aa0e5d29f9",
+		"data": {
+			"inGameID": 80000333,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1035,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1ddd848158e44b04235aec5923181af5d5eec20c",
+		"data": {
+			"inGameID": 80000333,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1035,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8c335f2c557d743485d0ed7587d86a078dc83b18",
+		"data": {
+			"inGameID": 80000334,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1036,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1f76d6fe111aaad3ad1601670b95ab04c0c2dea7",
+		"data": {
+			"inGameID": 80000334,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1036,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "3d45ace193569d9a3c634d261932836d8ee24367",
+		"data": {
+			"inGameID": 80000334,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1036,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9744fe410080a044cb35c74771e30d1665c0943d",
+		"data": {
+			"inGameID": 80000334,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1036,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c7063ff49ea668b47bd63df4660cf3e1546c2a84",
+		"data": {
+			"inGameID": 80000334,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1036,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4afd8fbed3546200ab6ed047685a4b4f99e874fe",
+		"data": {
+			"inGameID": 80000334,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1036,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "09e9cdfe03839e3482d0bd85352ec636c18007ce",
+		"data": {
+			"inGameID": 80000335,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1037,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "adf89fc0da8279f79dba73f9e632ceece6b7fbec",
+		"data": {
+			"inGameID": 80000335,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1037,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b9cbb9016103ed794116c3691b2eed974a938866",
+		"data": {
+			"inGameID": 80000335,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1037,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "7d254a29d7109d2daa0f11a280ca25e58520456e",
+		"data": {
+			"inGameID": 80000335,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1037,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "62f387242f3a1bbb632d403ed007d27160a6fa9f",
+		"data": {
+			"inGameID": 80000335,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1037,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "52c2270ffa91daae2b4c2cc0b7fadc3743b238ad",
+		"data": {
+			"inGameID": 80000335,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1037,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dcb9209014743f3f9f521443915d91cfbf3eaa6b",
+		"data": {
+			"inGameID": 80000336,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1038,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ad8f9089f3c20df2f4be95e11a3b133a62913c0f",
+		"data": {
+			"inGameID": 80000336,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1038,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f4e10b3746e871d01c26efd7e2adaf9bd39c86e4",
+		"data": {
+			"inGameID": 80000336,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1038,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6ea09cbb1243643165239816b37cef1ab3af6388",
+		"data": {
+			"inGameID": 80000336,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1038,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "41aca2e9f2bc858dac9e0fac95470f7c8ac41083",
+		"data": {
+			"inGameID": 80000336,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1038,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "fb68a2ba84c2ef4c102150a31130bb024aa0895a",
+		"data": {
+			"inGameID": 80000336,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1038,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "12883bcc8621c92d4beaf7c63a6e95d68c09cc8b",
+		"data": {
+			"inGameID": 80000337,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1039,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "14b2ff96f7a2a77e39e99b88177c5c4346b2b0c3",
+		"data": {
+			"inGameID": 80000337,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1039,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6a76acd4ab5e021d614545ccb0de2e445a76c449",
+		"data": {
+			"inGameID": 80000337,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1039,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "e4edfb6c52e439cc3959b7e866cb904271f4bf81",
+		"data": {
+			"inGameID": 80000337,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1039,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "935d664f8c4ecb736035ee26703a1bfca7c1d61c",
+		"data": {
+			"inGameID": 80000337,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1039,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d5df2344707f6514f8a091bca3f21a83ec4671bf",
+		"data": {
+			"inGameID": 80000337,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1039,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b87bc8edb1df89cdfdeba0c47f6ed7012c352217",
+		"data": {
+			"inGameID": 80000338,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1040,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "655b802393af5ba51d84997e2d83ec48ac85f280",
+		"data": {
+			"inGameID": 80000338,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1040,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ac95568fe23264496144ce6e2d02400c135d1297",
+		"data": {
+			"inGameID": 80000338,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1040,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "bec07dfeed5972d5f22d08118cecf4b7a771b5dc",
+		"data": {
+			"inGameID": 80000338,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1040,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "8f6fc128d7740512e63a7105be5b160d82054aa9",
+		"data": {
+			"inGameID": 80000338,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1040,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "31a3fbb0e84bcfbfadb58d9326a0f831de66a217",
+		"data": {
+			"inGameID": 80000338,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1040,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0353da85313550969c4405676865dc24bca13293",
+		"data": {
+			"inGameID": 80000339,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1041,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5b343940ef8731a126f315495c2c2e5f376e3c17",
+		"data": {
+			"inGameID": 80000339,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1041,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "54f6c40ccab74a27528bebc91ccd9498ab0ccfc1",
+		"data": {
+			"inGameID": 80000339,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1041,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "deb8d0ac6404156ff2917380e975f04f2fb97caa",
+		"data": {
+			"inGameID": 80000339,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1041,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "dba8b06cd766029bd638c1a04cb61f5f5f1f1208",
+		"data": {
+			"inGameID": 80000339,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1041,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a99450b0bf3dd970246dbf942bd7531893ea339f",
+		"data": {
+			"inGameID": 80000339,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1041,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5ecdbdfdcccfd14e9bb6fff9c0fdcaaed7bcb209",
+		"data": {
+			"inGameID": 80000340,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1042,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "193ecb429d6a583a4a609a2421bc5f8f7cb6b2db",
+		"data": {
+			"inGameID": 80000340,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1042,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "86d3ee9ac2fea6568f8faf1320a95fbbbc3df4ef",
+		"data": {
+			"inGameID": 80000340,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1042,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "960f232ed03a9135f3544aaed1039f5d53de983e",
+		"data": {
+			"inGameID": 80000340,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1042,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9c08d41934e6ecb358d78f5c2c653b463d5b6587",
+		"data": {
+			"inGameID": 80000340,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1042,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4f67a09d594b095dc535d1e4cc3b59fc58347696",
+		"data": {
+			"inGameID": 80000340,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1042,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "84903f2bdbad1da137bb88b533e0896e441922c6",
+		"data": {
+			"inGameID": 80000341,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1043,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f9dec0d9cee044a9418d8b98cbc55ed50dbf16e1",
+		"data": {
+			"inGameID": 80000341,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1043,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0e3b7b7d1bc4caca50246c15db529d3e8142c9b5",
+		"data": {
+			"inGameID": 80000341,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1043,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d3c0baf854dea8d8c0a9da108c1409a601d76acb",
+		"data": {
+			"inGameID": 80000341,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1043,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2ed0c5a321630beaa4efd1427ee304def6b0303e",
+		"data": {
+			"inGameID": 80000341,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1043,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5ecd4a2e8af5b2bcf13e76f1eaa5b2e2a963ae2d",
+		"data": {
+			"inGameID": 80000341,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1043,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4b84304bae7e698a59f2e71ccb71e80c2cfb6064",
+		"data": {
+			"inGameID": 80000342,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1044,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d1d9f7d2b12c2e91afb73840ca70ce99c2c79152",
+		"data": {
+			"inGameID": 80000342,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1044,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "737593f8e18a3cc65003288ecd86b2147ffd2e62",
+		"data": {
+			"inGameID": 80000342,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1044,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "736520d3b9504f18bee3b50531291e3d91a7d2f6",
+		"data": {
+			"inGameID": 80000342,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1044,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "f8069a095058ed872f9c0983d700c6a3f7f159cf",
+		"data": {
+			"inGameID": 80000342,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1044,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "78cbf5f641ef621e8bc294b4a3f218dd00c7371b",
+		"data": {
+			"inGameID": 80000342,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1044,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "5c5bd8570e7c65242ec2d780ea4300b44b5125d4",
+		"data": {
+			"inGameID": 80000343,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1045,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a431440feb67aac6e410346a2e29a205df0108bf",
+		"data": {
+			"inGameID": 80000343,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1045,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b6e32fe0ed24c079ec6c3e567b5ec44464407f87",
+		"data": {
+			"inGameID": 80000343,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1045,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ffbbcac50afae6f004ba5a20acfe94cd56d1d41d",
+		"data": {
+			"inGameID": 80000343,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1045,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2a47056e9061d485c62a2e67862a8f4695c6874f",
+		"data": {
+			"inGameID": 80000343,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1045,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "a01d0da7c63b5e77fe1a0b623cbf35a8c091f608",
+		"data": {
+			"inGameID": 80000343,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1045,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "255866a81b621a38af3254e1dd27891bdb4d1fd7",
+		"data": {
+			"inGameID": 80000344,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1046,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "b98995d16f82d0ff24f395848d36f1859d5531f8",
+		"data": {
+			"inGameID": 80000344,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1046,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "c49e374e5ccb7650f0d1b162d9649d52691dab40",
+		"data": {
+			"inGameID": 80000344,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1046,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "278a28f65ccaf400d047efe44f08a77b13709f62",
+		"data": {
+			"inGameID": 80000344,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1046,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "2e9b86a9ce02674ceaea76e5287c6fb16f3ed2fd",
+		"data": {
+			"inGameID": 80000344,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1046,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "801a6ebca5ca42a62b0a47880c96ee177544947f",
+		"data": {
+			"inGameID": 80000344,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1046,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ab0d70dbcfdde8a261fb25dc23b6f6ec96c2074b",
+		"data": {
+			"inGameID": 80000345,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1047,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "53343f8d9f05430965ec80956d8a3fc4a1ab8a3b",
+		"data": {
+			"inGameID": 80000345,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1047,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "efd5409a9f7ddb1f352cd9b08b0718936eb88fef",
+		"data": {
+			"inGameID": 80000345,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1047,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ba524e0aafbd2bdd2d1370810e2dcaa31bbd5712",
+		"data": {
+			"inGameID": 80000345,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1047,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "72a87d1b3844ec74171fd6f631670b32ae452ee3",
+		"data": {
+			"inGameID": 80000345,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1047,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "9d9a187d173adf9f151ea8ee78185b434320d03c",
+		"data": {
+			"inGameID": 80000345,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1047,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "adb7990013ac8bc1d54d6d7637230c031204b96a",
+		"data": {
+			"inGameID": 80000346,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1048,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ed66d93736f25330ad22e6366512b22ef6ab5477",
+		"data": {
+			"inGameID": 80000346,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1048,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "167efbbae44deddfc5597ae6d24803ec03df52b4",
+		"data": {
+			"inGameID": 80000346,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1048,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "38004bdb8b1cdb18e870cc92888f06b86ffa9b09",
+		"data": {
+			"inGameID": 80000346,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1048,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "822669e22b8e7aa73ff404e4908803b8ff8c6364",
+		"data": {
+			"inGameID": 80000346,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1048,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "ef5076c925cfe3fae82675ba972f1f95111929e5",
+		"data": {
+			"inGameID": 80000346,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1048,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "48225dbc51f631d206e3cb9e5eed0490877b84e1",
+		"data": {
+			"inGameID": 80000347,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1049,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "84ffa6ae226b3cfdc069ffc2afa31fa0e9327884",
+		"data": {
+			"inGameID": 80000347,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1049,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "4172e84b2570397e4b5a6f3056ff03624d35a84f",
+		"data": {
+			"inGameID": 80000347,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1049,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1006c7ea1db9d937dc7e9e9972cf0ac3aee1f741",
+		"data": {
+			"inGameID": 80000347,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1049,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "468ebd0b38f53d8cd874196e39d116a8fb1f5383",
+		"data": {
+			"inGameID": 80000347,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1049,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "6531d002df01c52d8155353d63d1e737a64ea462",
+		"data": {
+			"inGameID": 80000347,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1049,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "d3caff7e6d2ab30cd7b6c7103a8cc656e35f9922",
+		"data": {
+			"inGameID": 80001009,
+			"isHardMode": false
+		},
+		"difficulty": "ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1050,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "046757d03bb8bac00920f0b2f45cbf62749f8b98",
+		"data": {
+			"inGameID": 80001009,
+			"isHardMode": false
+		},
+		"difficulty": "BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1050,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0a827e12871160bc20e735ccfecea94b2a84a4c1",
+		"data": {
+			"inGameID": 80001009,
+			"isHardMode": false
+		},
+		"difficulty": "EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1050,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "0a65f363ecc407cd0c1b2edd752f8728dffecf04",
+		"data": {
+			"inGameID": 80001009,
+			"isHardMode": true
+		},
+		"difficulty": "HARD ADV",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1050,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "1a442ee5a968488a410649e8a97e7c440cc86c0a",
+		"data": {
+			"inGameID": 80001009,
+			"isHardMode": true
+		},
+		"difficulty": "HARD BSC",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1050,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
+		]
+	},
+	{
+		"chartID": "aceaf9f87b5333fbeca8bdad641caf49f570e740",
+		"data": {
+			"inGameID": 80001009,
+			"isHardMode": true
+		},
+		"difficulty": "HARD EXT",
+		"isPrimary": true,
+		"level": "9",
+		"levelNum": 9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 1050,
+		"tierlistInfo": {},
+		"versions": [
+			"clan"
 		]
 	}
 ]

--- a/collections/songs-jubeat.json
+++ b/collections/songs-jubeat.json
@@ -8998,5 +8998,1505 @@
 		"id": 900,
 		"searchTerms": [],
 		"title": "Our Faith [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "mihimaru GT",
+		"data": {
+			"displayVersion": "jubeat"
+		},
+		"id": 901,
+		"searchTerms": [],
+		"title": "気分上々↑↑"
+	},
+	{
+		"altTitles": [],
+		"artist": "相川七瀬",
+		"data": {
+			"displayVersion": "ripples"
+		},
+		"id": 902,
+		"searchTerms": [],
+		"title": "夢見る少女じゃいられない"
+	},
+	{
+		"altTitles": [],
+		"artist": "東方神起",
+		"data": {
+			"displayVersion": "ripples"
+		},
+		"id": 903,
+		"searchTerms": [],
+		"title": "Share The World"
+	},
+	{
+		"altTitles": [],
+		"artist": "FACT",
+		"data": {
+			"displayVersion": "ripples"
+		},
+		"id": 904,
+		"searchTerms": [],
+		"title": "a fact of life"
+	},
+	{
+		"altTitles": [],
+		"artist": "ブンブンサテライツ",
+		"data": {
+			"displayVersion": "knit"
+		},
+		"id": 905,
+		"searchTerms": [],
+		"title": "Kick It Out"
+	},
+	{
+		"altTitles": [],
+		"artist": "木村由姫",
+		"data": {
+			"displayVersion": "knit"
+		},
+		"id": 906,
+		"searchTerms": [],
+		"title": "LOVE & JOY"
+	},
+	{
+		"altTitles": [],
+		"artist": "ナオト・インティライミ",
+		"data": {
+			"displayVersion": "knit"
+		},
+		"id": 907,
+		"searchTerms": [],
+		"title": "カーニバる？"
+	},
+	{
+		"altTitles": [],
+		"artist": "mihimaru GT",
+		"data": {
+			"displayVersion": "copious"
+		},
+		"id": 908,
+		"searchTerms": [],
+		"title": "マスターピース"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 909,
+		"searchTerms": [],
+		"title": "オレンジ"
+	},
+	{
+		"altTitles": [],
+		"artist": "ST☆RISH",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 910,
+		"searchTerms": [],
+		"title": "マジLOVE1000%"
+	},
+	{
+		"altTitles": [],
+		"artist": "ストレイテナー",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 911,
+		"searchTerms": [],
+		"title": "From Noon Till Dawn feat.Tabu Zombie & Kunikazu Tanaka"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 912,
+		"searchTerms": [],
+		"title": "Dance My Generation"
+	},
+	{
+		"altTitles": [],
+		"artist": "MAN WITH A MISSION",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 913,
+		"searchTerms": [],
+		"title": "Get Off of My Way"
+	},
+	{
+		"altTitles": [],
+		"artist": "nano",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 914,
+		"searchTerms": [],
+		"title": "No pain"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 915,
+		"searchTerms": [],
+		"title": "V.I.P"
+	},
+	{
+		"altTitles": [],
+		"artist": "きゃりーぱみゅぱみゅ",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 916,
+		"searchTerms": [],
+		"title": "にんじゃりばんばん"
+	},
+	{
+		"altTitles": [],
+		"artist": "MIYAVI",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 917,
+		"searchTerms": [],
+		"title": "Ahead Of The Light"
+	},
+	{
+		"altTitles": [],
+		"artist": "fripSide",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 918,
+		"searchTerms": [],
+		"title": "sister's noise"
+	},
+	{
+		"altTitles": [],
+		"artist": "SEKAI NO OWARI",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 919,
+		"searchTerms": [],
+		"title": "RPG"
+	},
+	{
+		"altTitles": [],
+		"artist": "May'n",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 920,
+		"searchTerms": [],
+		"title": "ViViD"
+	},
+	{
+		"altTitles": [],
+		"artist": "ST☆RISH",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 921,
+		"searchTerms": [],
+		"title": "マジLOVE2000%"
+	},
+	{
+		"altTitles": [],
+		"artist": "小倉 唯",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 922,
+		"searchTerms": [],
+		"title": "Baby Sweet Berry Love"
+	},
+	{
+		"altTitles": [],
+		"artist": "きゃりーぱみゅぱみゅ",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 923,
+		"searchTerms": [],
+		"title": "インベーダーインベーダー"
+	},
+	{
+		"altTitles": [],
+		"artist": "livetune adding Fukase(from SEKAI NO OWARI)",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 924,
+		"searchTerms": [],
+		"title": "Take Your Way"
+	},
+	{
+		"altTitles": [],
+		"artist": "でんぱ組.inc",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 925,
+		"searchTerms": [],
+		"title": "でんでんぱっしょん"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 926,
+		"searchTerms": [],
+		"title": "キセキ"
+	},
+	{
+		"altTitles": [],
+		"artist": "ハジ→",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 927,
+		"searchTerms": [],
+		"title": "人生は素晴らしい物語。(Dear Japan Remix)"
+	},
+	{
+		"altTitles": [],
+		"artist": "E-girls",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 928,
+		"searchTerms": [],
+		"title": "Follow Me"
+	},
+	{
+		"altTitles": [],
+		"artist": "→Pia-no-jaC←",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 929,
+		"searchTerms": [],
+		"title": "METROPOLIS"
+	},
+	{
+		"altTitles": [],
+		"artist": "fripSide",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 930,
+		"searchTerms": [],
+		"title": "eternal reality"
+	},
+	{
+		"altTitles": [],
+		"artist": "ナノ",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 931,
+		"searchTerms": [],
+		"title": "SAVIOR OF SONG(feat. MY FIRST STORY)"
+	},
+	{
+		"altTitles": [],
+		"artist": "Trident (渕上 舞・沼倉愛美・山村 響)",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 932,
+		"searchTerms": [],
+		"title": "ブルー・フィールド"
+	},
+	{
+		"altTitles": [],
+		"artist": "→Pia-no-jaC←",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 933,
+		"searchTerms": [],
+		"title": "アイネクライネ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Petit Rabbit's",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 934,
+		"searchTerms": [],
+		"title": "Daydream café"
+	},
+	{
+		"altTitles": [],
+		"artist": "みかくにんぐッ！",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 935,
+		"searchTerms": [],
+		"title": "とまどい→レシピ"
+	},
+	{
+		"altTitles": [],
+		"artist": "fripSide",
+		"data": {
+			"displayVersion": "saucer"
+		},
+		"id": 936,
+		"searchTerms": [],
+		"title": "black bullet"
+	},
+	{
+		"altTitles": [],
+		"artist": "蒼井翔太",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 937,
+		"searchTerms": [],
+		"title": "MURASAKI"
+	},
+	{
+		"altTitles": [],
+		"artist": "北高文芸部女子会",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 938,
+		"searchTerms": [],
+		"title": "フレ降レミライ"
+	},
+	{
+		"altTitles": [],
+		"artist": "Charisma.com",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 939,
+		"searchTerms": [],
+		"title": "こんがらガール"
+	},
+	{
+		"altTitles": [],
+		"artist": "BABYMETAL",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 940,
+		"searchTerms": [],
+		"title": "メギツネ"
+	},
+	{
+		"altTitles": [],
+		"artist": "でんぱ組.inc",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 941,
+		"searchTerms": [],
+		"title": "バリ3共和国"
+	},
+	{
+		"altTitles": [],
+		"artist": "キュウソネコカミ",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 942,
+		"searchTerms": [],
+		"title": "MEGA SHAKE IT !"
+	},
+	{
+		"altTitles": [],
+		"artist": "有形ランペイジ",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 943,
+		"searchTerms": [],
+		"title": "世界五分前仮説"
+	},
+	{
+		"altTitles": [],
+		"artist": "内田真礼",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 944,
+		"searchTerms": [],
+		"title": "からっぽカプセル"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゲーム実況もっと！わくわく荘",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 945,
+		"searchTerms": [],
+		"title": "僕ガ壊レル前ニ"
+	},
+	{
+		"altTitles": [],
+		"artist": "A応P",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 946,
+		"searchTerms": [],
+		"title": "全力バタンキュー"
+	},
+	{
+		"altTitles": [],
+		"artist": "Petit Rabbit’s",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 947,
+		"searchTerms": [],
+		"title": "Daydream café [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 948,
+		"searchTerms": [],
+		"title": "キセキ [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "きゃりーぱみゅぱみゅ",
+		"data": {
+			"displayVersion": "prop"
+		},
+		"id": 949,
+		"searchTerms": [],
+		"title": "にんじゃりばんばん [ 2 ]"
+	},
+	{
+		"altTitles": [],
+		"artist": "筋肉少女帯",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 950,
+		"searchTerms": [],
+		"title": "混ぜるな危険"
+	},
+	{
+		"altTitles": [],
+		"artist": "アルスマグナ",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 951,
+		"searchTerms": [],
+		"title": "夏にキスしていいですか？"
+	},
+	{
+		"altTitles": [],
+		"artist": "[Alexandros]",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 952,
+		"searchTerms": [],
+		"title": "Famous Day"
+	},
+	{
+		"altTitles": [],
+		"artist": "Superfly",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 953,
+		"searchTerms": [],
+		"title": "Beautiful"
+	},
+	{
+		"altTitles": [],
+		"artist": "水曜日のカンパネラ",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 954,
+		"searchTerms": [],
+		"title": "ディアブロ"
+	},
+	{
+		"altTitles": [],
+		"artist": "chay",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 955,
+		"searchTerms": [],
+		"title": "あなたに恋をしてみました"
+	},
+	{
+		"altTitles": [],
+		"artist": "SEKAI NO OWARI",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 956,
+		"searchTerms": [],
+		"title": "ANTI-HERO"
+	},
+	{
+		"altTitles": [],
+		"artist": "新井大樹",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 957,
+		"searchTerms": [],
+		"title": "勇敢な髑髏"
+	},
+	{
+		"altTitles": [],
+		"artist": "ソナーポケット",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 958,
+		"searchTerms": [],
+		"title": "HERO"
+	},
+	{
+		"altTitles": [],
+		"artist": "学園生活部",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 959,
+		"searchTerms": [],
+		"title": "ふ・れ・ん・ど・し・た・い"
+	},
+	{
+		"altTitles": [],
+		"artist": "放課後ティータイム",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 960,
+		"searchTerms": [],
+		"title": "GO! GO! MANIAC"
+	},
+	{
+		"altTitles": [],
+		"artist": "泉こなた、柊かがみ、柊つかさ、高良みゆき",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 961,
+		"searchTerms": [],
+		"title": "もってけ！セーラーふく"
+	},
+	{
+		"altTitles": [],
+		"artist": "七森中☆ごらく部",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 962,
+		"searchTerms": [],
+		"title": "ちょちょちょ！ゆるゆり☆かぷりっちょ！！！"
+	},
+	{
+		"altTitles": [],
+		"artist": "fripSide",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 963,
+		"searchTerms": [],
+		"title": "Two souls -toward the truth-"
+	},
+	{
+		"altTitles": [],
+		"artist": "OxT",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 964,
+		"searchTerms": [],
+		"title": "Clattanoia"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 965,
+		"searchTerms": [],
+		"title": "君の知らない物語"
+	},
+	{
+		"altTitles": [],
+		"artist": "HaKU",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 966,
+		"searchTerms": [],
+		"title": "衝動"
+	},
+	{
+		"altTitles": [],
+		"artist": "ORANGE RANGE",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 967,
+		"searchTerms": [],
+		"title": "SUSHI食べたい feat.ソイソース"
+	},
+	{
+		"altTitles": [],
+		"artist": "[Alexandros]",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 968,
+		"searchTerms": [],
+		"title": "ワタリドリ"
+	},
+	{
+		"altTitles": [],
+		"artist": "[Alexandros]",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 969,
+		"searchTerms": [],
+		"title": "Girl A"
+	},
+	{
+		"altTitles": [],
+		"artist": "米津玄師",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 970,
+		"searchTerms": [],
+		"title": "アンビリーバーズ"
+	},
+	{
+		"altTitles": [],
+		"artist": "ジョー・リノイエ",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 971,
+		"searchTerms": [],
+		"title": "Synchronized Love J Rap Jam"
+	},
+	{
+		"altTitles": [],
+		"artist": "妹S",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 972,
+		"searchTerms": [],
+		"title": "ひだまりデイズ"
+	},
+	{
+		"altTitles": [],
+		"artist": "土間うまる(CV:田中あいみ)",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 973,
+		"searchTerms": [],
+		"title": "勇者うまるの華麗なる生活"
+	},
+	{
+		"altTitles": [],
+		"artist": "橘・シルフィンフォード(CV:古川由利奈)",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 974,
+		"searchTerms": [],
+		"title": "T・S・F in にっぽん！"
+	},
+	{
+		"altTitles": [],
+		"artist": "本場切絵(CV:白石晴香)",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 975,
+		"searchTerms": [],
+		"title": "My Precious"
+	},
+	{
+		"altTitles": [],
+		"artist": "海老名菜々(CV:影山灯)",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 976,
+		"searchTerms": [],
+		"title": "sweet sweet everytime sweet"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 977,
+		"searchTerms": [],
+		"title": "SAKURAスキップ"
+	},
+	{
+		"altTitles": [],
+		"artist": "猫大樹",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 978,
+		"searchTerms": [],
+		"title": "負けないよ･･･-Runners High-"
+	},
+	{
+		"altTitles": [],
+		"artist": "猫大樹",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 979,
+		"searchTerms": [],
+		"title": "男と女の言い合いのうた"
+	},
+	{
+		"altTitles": [],
+		"artist": "猫大樹",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 980,
+		"searchTerms": [],
+		"title": "夏休み is freedom!!"
+	},
+	{
+		"altTitles": [],
+		"artist": "猫大樹",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 981,
+		"searchTerms": [],
+		"title": "制作現場での出来事"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゲーム実況者わくわくバンド",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 982,
+		"searchTerms": [],
+		"title": "時の妖花"
+	},
+	{
+		"altTitles": [],
+		"artist": "ハジ→",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 983,
+		"searchTerms": [],
+		"title": "Dreamland。feat. RED RICE (from 湘南乃風), CICO (from BENNIE K)"
+	},
+	{
+		"altTitles": [],
+		"artist": "ももいろクローバーZ",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 984,
+		"searchTerms": [],
+		"title": "マホロバケーション"
+	},
+	{
+		"altTitles": [],
+		"artist": "9mm Parabellum Bullet",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 985,
+		"searchTerms": [],
+		"title": "インフェルノ"
+	},
+	{
+		"altTitles": [],
+		"artist": "でんぱ組. inc",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 986,
+		"searchTerms": [],
+		"title": "Ψです I LIKE YOU"
+	},
+	{
+		"altTitles": [],
+		"artist": "パスピエ",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 987,
+		"searchTerms": [],
+		"title": "ハイパーリアリスト"
+	},
+	{
+		"altTitles": [],
+		"artist": "中田ヤスタカ",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 988,
+		"searchTerms": [],
+		"title": "NANIMONO(feat.米津玄師)"
+	},
+	{
+		"altTitles": [],
+		"artist": "米津玄師",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 989,
+		"searchTerms": [],
+		"title": "翡翠の狼"
+	},
+	{
+		"altTitles": [],
+		"artist": "米津玄師",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 990,
+		"searchTerms": [],
+		"title": "LOSER"
+	},
+	{
+		"altTitles": [],
+		"artist": "A応P",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 991,
+		"searchTerms": [],
+		"title": "お茶づけ☆パラダイス"
+	},
+	{
+		"altTitles": [],
+		"artist": "A応P",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 992,
+		"searchTerms": [],
+		"title": "ちょちょいとちょいだよ夢浪漫"
+	},
+	{
+		"altTitles": [],
+		"artist": "A応P",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 993,
+		"searchTerms": [],
+		"title": "椀・of・Relaxation"
+	},
+	{
+		"altTitles": [],
+		"artist": "S-C-U a.k.a. Food Samurai×A応P",
+		"data": {
+			"displayVersion": "qubell"
+		},
+		"id": 994,
+		"searchTerms": [],
+		"title": "拙者はSAMURAI FOOD"
+	},
+	{
+		"altTitles": [],
+		"artist": "ガヴリール、ヴィーネ、サターンや、ラフィエル",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 995,
+		"searchTerms": [],
+		"title": "ガヴリールドロップキック"
+	},
+	{
+		"altTitles": [],
+		"artist": "(K)NoW_NAME",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 996,
+		"searchTerms": [],
+		"title": "Morning Glory"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 997,
+		"searchTerms": [],
+		"title": "STEP by STEP UP↑↑↑↑"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 998,
+		"searchTerms": [],
+		"title": "JUMPin' JUMP UP！！！！"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 999,
+		"searchTerms": [],
+		"title": "ススメRunner！！"
+	},
+	{
+		"altTitles": [],
+		"artist": "どうぶつビスケッツ✕PPP",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1000,
+		"searchTerms": [],
+		"title": "ようこそジャパリパークへ"
+	},
+	{
+		"altTitles": [],
+		"artist": "ONE III NOTES",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1001,
+		"searchTerms": [],
+		"title": "Shadow and Truth"
+	},
+	{
+		"altTitles": [],
+		"artist": "GRANRODEO",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1002,
+		"searchTerms": [],
+		"title": "Glorius days"
+	},
+	{
+		"altTitles": [],
+		"artist": "fourfolium",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1003,
+		"searchTerms": [],
+		"title": "ユメイロコンバス"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1004,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ青森～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1005,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ岩手～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1006,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ宮城～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1007,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ秋田～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1008,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ山形～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1009,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ福島～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1010,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ茨城～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1011,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ栃木～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1012,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ群馬～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1013,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ埼玉～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1014,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ千葉～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1015,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ東京～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1016,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ神奈川～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1017,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ新潟～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1018,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ富山～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1019,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ石川～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1020,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ福井～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1021,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ山梨～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1022,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ長野～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1023,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ岐阜～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1024,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ静岡～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1025,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ愛知～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1026,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ三重～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1027,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ滋賀～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1028,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ京都～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1029,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ大阪～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1030,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ兵庫～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1031,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ奈良～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1032,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ和歌山～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1033,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ鳥取～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1034,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ島根～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1035,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ岡山～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1036,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ広島～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1037,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ山口～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1038,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ徳島～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1039,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ香川～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1040,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ愛媛～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1041,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ高知～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1042,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ福岡～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1043,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ佐賀～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1044,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ長崎～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1045,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ熊本～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1046,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ大分～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1047,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ宮崎～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1048,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ鹿児島～"
+	},
+	{
+		"altTitles": [],
+		"artist": "ゴールデンボンバー",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1049,
+		"searchTerms": [],
+		"title": "やんややんやNight～踊ろよ沖縄～"
+	},
+	{
+		"altTitles": [],
+		"artist": "",
+		"data": {
+			"displayVersion": "clan"
+		},
+		"id": 1050,
+		"searchTerms": [],
+		"title": "君の知らない物語 [ 2 ]"
 	}
 ]

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -40,7 +40,7 @@
 		"monk": "^7.3.4",
 		"node-fetch": "2.6.7",
 		"prudence": "^0.9.7",
-		"tachi-common": "0.11.4",
+		"tachi-common": "0.11.5",
 		"ts-node": "^10.4.0",
 		"xml2js": "^0.4.23"
 	},

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -40,7 +40,7 @@
 		"monk": "^7.3.4",
 		"node-fetch": "2.6.7",
 		"prudence": "^0.9.7",
-		"tachi-common": "0.11.3",
+		"tachi-common": "0.11.4",
 		"ts-node": "^10.4.0",
 		"xml2js": "^0.4.23"
 	},

--- a/scripts/pnpm-lock.yaml
+++ b/scripts/pnpm-lock.yaml
@@ -25,7 +25,7 @@ specifiers:
   node-fetch: 2.6.7
   prettier: ^2.5.1
   prudence: ^0.9.7
-  tachi-common: 0.11.3
+  tachi-common: 0.11.5
   ts-node: ^10.4.0
   typescript: ^4.5.5
   xml2js: ^0.4.23
@@ -48,7 +48,7 @@ dependencies:
   monk: 7.3.4
   node-fetch: 2.6.7
   prudence: 0.9.7
-  tachi-common: 0.11.3
+  tachi-common: 0.11.5
   ts-node: 10.4.0_40146b36d18138e3202fbb722e5f65e4
   xml2js: 0.4.23
 
@@ -3113,8 +3113,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tachi-common/0.11.3:
-    resolution: {integrity: sha512-McFWWxbrzLvbo4M7p69xhvlC7FZL2c4b+/nID+PZtJpf1YfqtxvzYkX3ZWEfC+SOL9rHriffdk5G6MvcDP87cQ==}
+  /tachi-common/0.11.5:
+    resolution: {integrity: sha512-MCaDj8nLjhA8QezlKGU6iZ7RM3wSvgXIsOiMGY6bk0Cfwji/dSHfaMEkbc4sdiLZUXbzUKcVseL30G4GezL10w==}
     dependencies:
       '@types/express-serve-static-core': 4.17.28
       '@types/mongodb': 3.6.18


### PR DESCRIPTION
I wrote a script to add charts and songs to the corresponding json files for Jubeat. Song titles and artists were manually fetched. The chartID strings were generated using `secrets.token_hex(20)`, and was not checked for duplicates in existing chart files for any game. New additions were appended to the end of the array, with `songID` starting from 901. the 6 charts per song were added in the difficulty order: `ADV`, `BSC`, `EXT`, `HARD ADV`, `HARD BSC`, `HARD EXT`, per song. The `displayVersion` strings were derived from the first digit of the `inGameID`. The levels in Jubeat Clan only have integer values. As such, the `level` and `levelNum` values are (string) integers. Charts which appear in both Clan and Festo have `clan` inserted into the `versions` array for each chart. 