### PR TITLE
add new wacca charts

### DIFF
--- a/collections/charts-wacca.json
+++ b/collections/charts-wacca.json
@@ -18811,5 +18811,668 @@
 		"versions": [
 			"reverse"
 		]
+	},
+	{
+		"chartID": "363da6e30739d82d2c4472fa7dbb82c1348f247d",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 362,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "47118e566fe0e2c2461b584e92ce0b2df04bbeff",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "11",
+		"levelNum": 11,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 362,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "9cb463c776df78fc66a7229d8e8f016c9e737316",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 362,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "38e8a592126e173267cadba23eb7454ce7f70420",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13.3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 363,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "f9d25143b0e7312bce14fdadc7ca700917516dc3",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "6",
+		"levelNum": 6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 363,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "05feb6826ce5cc10bca66af9040d7cf8d07674ff",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "2",
+		"levelNum": 2,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 363,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "f5005553a7ff656de76b74e6cbc616ea3b699b07",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "12+",
+		"levelNum": 12.9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 364,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "b9e8f638d040c02405868193b3bcfdb5be183b41",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7.6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 364,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "d8752b2091563a578efdab9f7eb53b772c4888ed",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 364,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "d79e55ea180e9e22afe4809c2d017ba3daf1d36d",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "12+",
+		"levelNum": 12.9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 365,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "a86868788a2c8fba6b3efc70c18c514d039d7673",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "7+",
+		"levelNum": 7.9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 365,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "da23fafab9fff4d46491dbf9ff261b5fd2c178c1",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 365,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "5d60ef53fd1b68b3c2db82ae41af934102a39402",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 366,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "8511000e812ef4652d9c7259fa77d62b0bbfbc6b",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "10+",
+		"levelNum": 10.9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 366,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "482b970d8f9e90b27dfb5f3cad730d74594bb2af",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 366,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "c21c6e57d252331352b2f7c7b2592e9a7b57e4fe",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 367,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "2286abc5b49dc3a915c2e49d7181bb3b449b6f4a",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "10+",
+		"levelNum": 10.9,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 367,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "09756e176996e5c25d249f1b68b651e2a9fc950b",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 367,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "719f626756b01ed7df70f921b5668fa0e888c39d",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "11+",
+		"levelNum": 11.8,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 368,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "d11f8739a5f39ce86567106438081b29d9b86448",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "7",
+		"levelNum": 7.5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 368,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "9b7e251f6f558b8a9b80d6cf5666650aba215d24",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 368,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "241da787ce73db3b8b4353c41577fb5b1e6819d7",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "14",
+		"levelNum": 14,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 369,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "5f8ec1c17ccf6ac5b061346bbb422f2c30312f27",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "11",
+		"levelNum": 11,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 369,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "0402dc369ea3c886443df46d8db7325a95be0484",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 369,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "3ff4a14ee6ffa01a2b62de225623bef5765306e8",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 370,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "3782ebcbcc788e59806a676137e1bdc64c910b2f",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "10+",
+		"levelNum": 10.7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 370,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "4450b915df5e4e527a43c3db251b48a94fa21f56",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 370,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "60d753dc31044b7bec8661f5d2e3f8bb6387ab3e",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13+",
+		"levelNum": 13.7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 371,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "924bf7355a9bf81598c07e9ae8d3c5f6eb061435",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10.6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 371,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "341e96fbe7c3028fceeea36dc72d21f5cb3bc62f",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 371,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "7fda1a54ae03ae9705e38842d9a85322652ea177",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "12+",
+		"levelNum": 12.7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 372,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "dca4bc9529243d4352f2ddac2a45da566134ef9a",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "10",
+		"levelNum": 10.4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 372,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "30f4834016613a89f9e945dc556f0d1da56cd397",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "4",
+		"levelNum": 4,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 372,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "e7b68a451812991541a86a6f5835dff5c99e5fcf",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "13",
+		"levelNum": 13.3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 373,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "fddbeff70f793709ae9b1b1788b75b38d2bc7903",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "8+",
+		"levelNum": 8.7,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 373,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "5d587427093541ac8b4e84548c66c5d5829081c4",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "5",
+		"levelNum": 5,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 373,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "cb8611211732e2ec38e375c83077777d21bd9eaa",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "EXPERT",
+		"isPrimary": true,
+		"level": "12",
+		"levelNum": 12.3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 374,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "af37d0cd4c6a4ff13270474b031717122e71483b",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "HARD",
+		"isPrimary": true,
+		"level": "8",
+		"levelNum": 8.6,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 374,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
+	},
+	{
+		"chartID": "50a07142dba8fa538e657e58951c170e36928f0a",
+		"data": {
+			"isHot": true
+		},
+		"difficulty": "NORMAL",
+		"isPrimary": true,
+		"level": "3",
+		"levelNum": 3,
+		"playtype": "Single",
+		"rgcID": null,
+		"songID": 374,
+		"tierlistInfo": {},
+		"versions": [
+			"reverse"
+		]
 	}
 ]

--- a/collections/songs-wacca.json
+++ b/collections/songs-wacca.json
@@ -5051,5 +5051,178 @@
 		"id": 361,
 		"searchTerms": [],
 		"title": "You & DIE"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Myosuke",
+		"data": {
+			"artistJP": "ディージェーミョースケ",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "エクストラハード"
+		},
+		"id": 362,
+		"searchTerms": [],
+		"title": "EXTRA HARD"
+	},
+	{
+		"altTitles": [],
+		"artist": "Kobaryo",
+		"data": {
+			"artistJP": "コバリョー",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "オブテイン　アン　アンユーズド　ホエール　イン　ジ　アブストラクト　シー"
+		},
+		"id": 363,
+		"searchTerms": [],
+		"title": "Obtain An Unused Whale In The Abstract Sea"
+	},
+	{
+		"altTitles": [],
+		"artist": "Srav3R",
+		"data": {
+			"artistJP": "スレイバー",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "ミドル"
+		},
+		"id": 364,
+		"searchTerms": [],
+		"title": "Middle"
+	},
+	{
+		"altTitles": [],
+		"artist": "aran",
+		"data": {
+			"artistJP": "アラン",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "アヴェニュー"
+		},
+		"id": 365,
+		"searchTerms": [],
+		"title": "Avenue"
+	},
+	{
+		"altTitles": [],
+		"artist": "Massive New Krew & RoughSketch",
+		"data": {
+			"artistJP": "マッシブニュークルーアンドラフスケッチ",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "エクストリームオンガクスクールフィーチャリングナナヒラ"
+		},
+		"id": 366,
+		"searchTerms": [
+			"Extreme ↑↑ Ongaku School feat. nanahira"
+		],
+		"title": "えくすとりーむ↑↑おんがくスクール feat. ななひら"
+	},
+	{
+		"altTitles": [],
+		"artist": "t+pazolite",
+		"data": {
+			"artistJP": "トパゾライト",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "ティープラスブイエスシャーク"
+		},
+		"id": 367,
+		"searchTerms": [],
+		"title": "T+ VS SHARK"
+	},
+	{
+		"altTitles": [],
+		"artist": "aran",
+		"data": {
+			"artistJP": "アラン",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "ブランニューワールド フューチャリング　ユカッコ"
+		},
+		"id": 368,
+		"searchTerms": [],
+		"title": "Brand New World feat. Yukacco"
+	},
+	{
+		"altTitles": [],
+		"artist": "Kobaryo feat. HiTNEX-X",
+		"data": {
+			"artistJP": "コバリョー　フィーチャリング　ヒットネックス　エックス",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "スーパー　エミュレーター"
+		},
+		"id": 369,
+		"searchTerms": [],
+		"title": "SUPER EMULATOR"
+	},
+	{
+		"altTitles": [],
+		"artist": "Getty",
+		"data": {
+			"artistJP": "ゲッティー",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "ガッキー"
+		},
+		"id": 370,
+		"searchTerms": [],
+		"title": "GAKKY"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Noriken",
+		"data": {
+			"artistJP": "ディージェーノリケン",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "ナイトウェーブフラグメンツ"
+		},
+		"id": 371,
+		"searchTerms": [],
+		"title": "NIGHTWAVE FRAGMENTS"
+	},
+	{
+		"altTitles": [],
+		"artist": "Srav3R",
+		"data": {
+			"artistJP": "スレイバー",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "ネクステージ"
+		},
+		"id": 372,
+		"searchTerms": [
+			"NEXTAGE"
+		],
+		"title": "N3XTAGE"
+	},
+	{
+		"altTitles": [],
+		"artist": "USAO",
+		"data": {
+			"artistJP": "ウサオ",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "ビッグダディ"
+		},
+		"id": 373,
+		"searchTerms": [],
+		"title": "Big Daddy"
+	},
+	{
+		"altTitles": [],
+		"artist": "DJ Genki",
+		"data": {
+			"artistJP": "ディージェーゲンキ",
+			"displayVersion": "reverse",
+			"genre": "TANO*C",
+			"titleJP": "レディーゴーフィーチャリングユカッコ"
+		},
+		"id": 374,
+		"searchTerms": [],
+		"title": "Ready Go feat. Yukacco"
 	}
 ]

--- a/scripts/rerunners/parse-wacca-dataset.js
+++ b/scripts/rerunners/parse-wacca-dataset.js
@@ -66,9 +66,12 @@ const STARTS = {
 };
 
 (async () => {
-	const existingSongs = new Map(ReadCollection("songs-wacca.json").map((e) => [e.title, e.id]));
+	const songs = ReadCollection("songs-wacca.json");
+	const charts = ReadCollection("charts-wacca.json");
+
+	const existingSongs = new Map(songs.map((e) => [e.title, e.id]));
 	const existingCharts = new Map(
-		ReadCollection("charts-wacca.json").map((e) =>
+		charts.map((e) =>
 			// We need to combine songID and difficulty for the key,
 			// this seems like the simplest way.
 			[`${e.songID} ${e.difficulty}`, e.chartID]
@@ -82,9 +85,6 @@ const STARTS = {
 		},
 		body: "cat=all",
 	}).then((r) => r.json());
-
-	const songs = [];
-	const charts = [];
 
 	let songID = Math.max(...existingSongs.values()) + 1;
 
@@ -142,24 +142,27 @@ const STARTS = {
 			thisSongID = existingSongs.get(title);
 		} else {
 			songID++;
+			songs.push({
+				id: thisSongID,
+				title,
+				artist: decode(data.artist.display).trim(),
+				searchTerms,
+				altTitles,
+				data: {
+					titleJP: decode(data.title.ruby),
+					artistJP: decode(data.artist.ruby),
+					genre: decode(data.category),
+					displayVersion: ver,
+				},
+			});
 		}
-		songs.push({
-			id: thisSongID,
-			title,
-			artist: decode(data.artist.display).trim(),
-			searchTerms,
-			altTitles,
-			data: {
-				titleJP: decode(data.title.ruby),
-				artistJP: decode(data.artist.ruby),
-				genre: decode(data.category),
-				displayVersion: ver,
-			},
-		});
 
 		for (const cols of difficultyCols) {
 			const diff = record[cols.levelCol];
 			const [diffName, level] = diff.split(" ");
+			if (existingCharts.get(`${thisSongID} ${diffName}`)) {
+				continue;
+			}
 			const levelNum = Number(record[cols.constantCol]);
 			const isHot = record[cols.newerCol] === "true";
 
@@ -167,7 +170,7 @@ const STARTS = {
 				continue;
 			}
 
-			const chartID = existingCharts.get(`${thisSongID} ${diffName}`) || CreateChartID();
+			const chartID = CreateChartID();
 
 			charts.push({
 				songID: thisSongID,


### PR DESCRIPTION
There is one new song added to the game every day until I think July 19, so there will be a lot more. This is the first batch.
The script was updated to avoid removing songs that are gone from the website. A bunch of songs were removed from the game and they finally took them off the website so this avoids that issue. I may file another PR that removes them from the "reverse" version, but it's not happening in this one.
Test failures were introduced by AI table update in a prior commit, all the wacca tests pass.
Hope all is well :pray: and thanks for taking a look.